### PR TITLE
Healthlock bug row 5. Look at login_needs_correction as well for cred…

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Version
 
-### 0.4.2
+### 0.4.3
 
 ## Philosophy
 This SDK is designed to implement the [EasyEnrollment platform](https://www.easyenrollment.net) into our clients own hosted web-portals. We want to make it fit as seemlessly as possible with the current experience of their sites; because of this, we have provided functionality to add callbacks to the end of each of the necessary flows and we are as unopinionated as possible about the styling of the SDK's flow.

--- a/assets/react/components/sdk.jsx
+++ b/assets/react/components/sdk.jsx
@@ -167,7 +167,11 @@ class SDK extends Component {
           this.setState({
             termsOfUse: false,
             taskId: this.props.realTimeVerification ? taskId : null,
-            credentialsValid: taskId ? null : true,
+            credentialsValid: taskId
+              ? null
+              : phData.login_problem !== null
+              ? !phData.login_needs_correction
+              : true,
             policyHolderId: policyHolderId,
             streamPolicyHolder: phData,
             step: 5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-connect-sdk",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-connect-sdk",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A JavaScript SDK implementing TPAStream's Connect Platform",
   "scripts": {
     "build": "webpack --config webpack.prod-sdk.js --mode=production",


### PR DESCRIPTION
…entials are valid on initial request.

As per our discussion from HealthLock today. If taskId ends up null because of race conditions check login problem before assuming credentials. If login_problem exists then set credentialsValid = !policyHolder.login_needs_correction.