### PR TITLE
sdk-hook: require connectAccessToken for beginFixCredentials

### DIFF
--- a/assets/sdk-hook/entries/sdk-hook.js
+++ b/assets/sdk-hook/entries/sdk-hook.js
@@ -42,6 +42,7 @@ export default class StreamConnect {
     });
     this.props = {
       apiToken,
+      connectAccessToken,
       tenant,
       employer,
       user,
@@ -110,6 +111,11 @@ export default class StreamConnect {
   };
 
   beginFixCredentials = () => {
+    if (!this.props.connectAccessToken) {
+      throw new Error(
+        'You must have a connect access token enabled and set to use fix-credentials functionality. See https://github.com/TPAStream/stream-connect-js-sdk/blob/master/docs/connect-access-token.md'
+      );
+    }
     this.setState({ step: steps.step2 });
     return this.state;
   };

--- a/assets/tests/sdk-hook.test.js
+++ b/assets/tests/sdk-hook.test.js
@@ -1,0 +1,19 @@
+import StreamConnect from '../sdk-hook/entries/sdk-hook';
+
+describe('StreamConnect.beginFixCredentials', () => {
+  it('throws when no connectAccessToken was provided at construction', () => {
+    const sc = new StreamConnect({ apiToken: 'token' });
+    expect(() => sc.beginFixCredentials()).toThrow(
+      /connect access token/i
+    );
+  });
+
+  it('transitions to fix-credentials step when a connectAccessToken is present', () => {
+    const sc = new StreamConnect({
+      apiToken: 'token',
+      connectAccessToken: 'connect-token'
+    });
+    const state = sc.beginFixCredentials();
+    expect(state.step).toBe('fix-credentials');
+  });
+});


### PR DESCRIPTION
## Summary
- Mirrors the existing React SDK guard (`assets/sdk/components/sdk.jsx:342-350`) on the sdk-hook entry point: if a host calls `beginFixCredentials()` without having provided `connectAccessToken` at construction, throw loudly at the step transition instead of firing `GET /sdk-api/fix-credentials` with no `X-Connect-Access-Token` header.
- The missing-header request is the source of the Sentry [WEBAPP-DNQ](https://sentry.sso.tpastream.com/organizations/sentry/issues/406036/) group — 260 events from an Android WebView host.
- Adds `connectAccessToken` to `this.props` so the guard can read it.
- New `assets/tests/sdk-hook.test.js` covers both paths.

## Companion server PR
https://github.com/LakeEriePartners/stream/pull/14017 — converts the 500 `AssertionError` response on the server to a 422, so mis-configured hosts get a clean error instead of Sentry noise regardless of SDK version.

## Test plan
- [x] `npx jest --config=jest.config.js` → 19 passed (17 existing + 2 new)
- [ ] Verify downstream host (Android WebView integration) surfaces the new error gracefully after bumping to this SDK version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
