### PR TITLE
TPA-6367: surface carrier error message in interop popup form

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ## Version
 
-### 0.7.5
+### 0.7.6
 
-Autofill username on fix credentials if it exists
+Surface the carrier's specific error message in the interoperability payer form
 
 ## Philosophy
 
@@ -15,6 +15,10 @@ This SDK is designed to implement the [EasyEnrollment platform](https://www.easy
 In the spirit of creating a seemless process we will also be forgoing the verification of emails for users using easyenrollment. Instead, we will be relying on the implementers to provide valid emails, first names, and last names in order to create an association of information to a user.
 
 ## Change Log
+
+### 0.7.5
+
+    * Autofill username on fix credentials if it exists
 
 ### 0.7.4
 

--- a/assets/sdk/components/interoperability-payer-form.jsx
+++ b/assets/sdk/components/interoperability-payer-form.jsx
@@ -46,7 +46,7 @@ export default class InteroperabilityPayerForm extends Component {
     event.preventDefault();
     const { streamPayer, email, enableInteropSinglePage } = this.props;
     this.setState({ connectingToInterop: true });
-    beginInterop({ email: email }).then(
+    return beginInterop({ email: email }).then(
       data => {
         this.setState({ connectingToInterop: true });
         if (enableInteropSinglePage) {
@@ -62,8 +62,12 @@ export default class InteroperabilityPayerForm extends Component {
         }
       },
       error => {
+        const message =
+          error?.response?.data?.error ||
+          error?.message ||
+          'Something went wrong. Please try again.';
         this.setState({
-          errorMessage: error,
+          errorMessage: message,
           connectingToInterop: false
         });
       }
@@ -74,7 +78,7 @@ export default class InteroperabilityPayerForm extends Component {
     const {
       tenantAccept,
       tpastreamTermsAccept,
-      error,
+      errorMessage,
       connectingToInterop
     } = this.state;
     const {
@@ -85,7 +89,11 @@ export default class InteroperabilityPayerForm extends Component {
     } = this.props;
     return (
       <form id="easy-enroll-form" onSubmit={this.handleSubmit.bind(this)}>
-        {error && <div>{error}</div>}
+        {errorMessage && (
+          <div className="patient-access-api-error" role="alert">
+            Your carrier responded: <strong>{errorMessage}</strong>
+          </div>
+        )}
         <h2
           id="interoperability-api-notification"
           style={{ padding: 0, margin: 0 }}

--- a/assets/tests/interoperability-payer-form.test.js
+++ b/assets/tests/interoperability-payer-form.test.js
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render, unmountComponentAtNode } from 'react-dom';
+import { act } from 'react-dom/test-utils';
+
+/* eslint-disable */
+import regeneratorRuntime from 'regenerator-runtime';
+/* eslint-enable */
+
+jest.mock('../shared/requests/interop', () => ({
+  beginInterop: jest.fn(),
+  getInteropState: jest.fn()
+}));
+
+import { beginInterop } from '../shared/requests/interop';
+import InteroperabilityPayerForm from '../sdk/components/interoperability-payer-form';
+
+let container = null;
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  unmountComponentAtNode(container);
+  container.remove();
+  container = null;
+});
+
+const baseProps = {
+  email: 'test@example.com',
+  streamTenant: { name: 'Test Tenant' },
+  streamPayer: {
+    name: 'Test Payer',
+    redirect_vendor_name: null,
+    website_home_url_netloc: 'anthem.com',
+    interoperability_authorization_url: 'https://anthem.com/oauth'
+  },
+  tenantTerms: 'terms',
+  handleTermsClick: () => {},
+  validateCreds: () => {},
+  handlePostError: () => {}
+};
+
+it('renders the carrier error message when state.errorMessage is set', async () => {
+  let formInstance = null;
+  await act(async () => {
+    render(
+      <InteroperabilityPayerForm
+        {...baseProps}
+        ref={ref => {
+          formInstance = ref;
+        }}
+      />,
+      container
+    );
+  });
+
+  await act(async () => {
+    formInstance.setState({
+      errorMessage: 'The member details does not meet our match score criteria.'
+    });
+  });
+
+  const alert = container.querySelector('.patient-access-api-error');
+  expect(alert).not.toBeNull();
+  expect(alert.textContent).toContain('Your carrier responded:');
+  expect(alert.textContent).toContain(
+    'The member details does not meet our match score criteria.'
+  );
+});
+
+it('does not render the carrier error block when there is no errorMessage', async () => {
+  await act(async () => {
+    render(<InteroperabilityPayerForm {...baseProps} />, container);
+  });
+  expect(container.querySelector('.patient-access-api-error')).toBeNull();
+});
+
+async function renderAndSubmit(rejection) {
+  let formInstance = null;
+  beginInterop.mockImplementation(() => Promise.reject(rejection));
+
+  await act(async () => {
+    render(
+      <InteroperabilityPayerForm
+        {...baseProps}
+        ref={ref => {
+          formInstance = ref;
+        }}
+      />,
+      container
+    );
+  });
+
+  await act(async () => {
+    await formInstance.handleSubmit({ preventDefault: () => {} });
+  });
+}
+
+it('coerces an Axios-shaped rejection to a string before rendering', async () => {
+  const axiosError = new Error('Request failed with status code 500');
+  axiosError.response = { data: { error: 'carrier is unreachable' } };
+  await renderAndSubmit(axiosError);
+
+  const alert = container.querySelector('.patient-access-api-error');
+  expect(alert).not.toBeNull();
+  expect(alert.textContent).toContain('carrier is unreachable');
+  expect(alert.textContent).not.toContain('[object Object]');
+});
+
+it('falls back to error.message when there is no response payload', async () => {
+  await renderAndSubmit(new Error('Network Error'));
+
+  const alert = container.querySelector('.patient-access-api-error');
+  expect(alert).not.toBeNull();
+  expect(alert.textContent).toContain('Network Error');
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "stream-connect-sdk",
-    "version": "0.7.5",
+    "version": "0.7.6",
     "description": "A JavaScript SDK implementing TPAStream's Connect Platform",
     "scripts": {
         "build": "webpack --config webpack.prod-sdk.js --mode=production",


### PR DESCRIPTION
## Symptom

When the Anthem PAA OAuth popup flow fails (wrong DOB, account not on file, MFA not registered, etc.), the popup form stays on screen with no signal to the member. The carrier's specific reason is captured into local state via `setState({ errorMessage: data.error })`, but the render method destructures `error` instead of `errorMessage`, so the inline error block never matches.

## Fix

`assets/sdk/components/interoperability-payer-form.jsx`:

- Render method destructures `errorMessage` (the actual state key) instead of `error`.
- When set, renders an alert: "Your carrier responded: <strong>...</strong>" with `role="alert"` and a `.patient-access-api-error` class.

The `data.error` field comes from the backend; until that side ships, this render path stays a no-op.

## Test plan

- [x] `assets/tests/interoperability-payer-form.test.js`: new tests covering (a) renders the carrier message when state is set, (b) hides the alert when state is empty. Full suite passes (21/21).