### PR TITLE
docs/client-usage: revamp for 0.8 reality + first-time readers

### DIFF
--- a/docs/client-usage.md
+++ b/docs/client-usage.md
@@ -1,114 +1,190 @@
-
 # Client Usage
-We have decided that the best possible way to implement this SDK is a simple config pattern. A prospective user will communicate with us to receive an SDK sdkToken as well as employer system keys.
 
-A mock implementation might look something like the following:
+> **Upgrading from 0.7?** See the [0.7 → 0.8 migration guide](./migration-0.7-to-0.8.md).
 
-Using TPAStream as a CDN
+Mount the SDK by calling `StreamConnect({...})` with your config. The minimum you need is `el` (where to mount), `employer`, `user`, and `apiToken`. Everything else has sane defaults.
+
+![SDK default UI](./flow-screenshots/choose-payer.png)
+
+## Quickstart
+
+### Via CDN (vanilla HTML, server-rendered, Backbone, jQuery)
+
 ```html
-    <script src="https://app.tpastream.com/static/js/sdk.js"></script>
-    <script>
-        window.StreamConnect({
-            el: '#react-hook', // CSS selector; the SDK renders under this element.
-            employer: {
-                systemKey: 'some-system-key',
-                vendor: 'internal',
-                name: 'some-employer-name'
-            },
-            user: {
-                firstName: 'Joe',
-                lastName: 'Sajor',
-                email: 'some-email@place.com'
-            },
-            isDemo: false,
-            sdkToken: 'VeryLegitKey',
-            // Optional 0.8 additions:
-            theme: { primaryColor: '#2563eb' },
-            enablePatientAccessAPI: true,
-            // Behavior toggles (defaults shown):
-            realTimeVerification: true,
-            renderChoosePayer: true,
-            renderPayerForm: true,
-            renderEndWidget: true,
-            // Lifecycle callbacks:
-            doneGetSDK: ({ user, payers, tenant, employer }) => {},
-            doneChoosePayer: () => {},
-            doneTermsOfService: () => {},
-            doneCreatedForm: () => {},
-            donePostCredentials: ({ params }) => {},
-            doneRealTime: () => {},
-            doneEasyEnroll: ({ employer, payer, tenant, policyHolder, user }) => {},
-            donePopUp: () => {},
-            handleFormErrors: (error, {response, request, config}) => {}
-        })
-    </script>
+<script src="https://app.tpastream.com/static/js/sdk-v-0.8.0.js"></script>
+<div id="sdk-hook"></div>
+<script>
+  window.StreamConnect({
+    el: '#sdk-hook',
+    employer: { vendor: 'internal', systemKey: 'EMP-123' },
+    user: {
+      firstName: 'Joe',
+      lastName: 'Sample',
+      email: 'joe@example.com',
+    },
+    apiToken: 'YOUR-SDK-TOKEN',
+  });
+</script>
 ```
 
-As shown above the SDK is mounted by calling `window.StreamConnect({})` and passing in the desired parameters.
+Three CDN forms are supported:
 
-As of SDK version 0.4.7 the CDN provider is versioned. Past versions remain available indefinitely.
- * The version is selected by the `src` attribute on your script tag.
-    * `"https://app.tpastream.com/static/js/sdk.js"` -> Latest published version of the SDK.
-    * `"https://app.tpastream.com/static/js/sdk-v-<VersionNumber>.js"` -> A specific version. Examples:
-        * `"https://app.tpastream.com/static/js/sdk-v-0.8.0.js"` (current 0.8)
-        * `"https://app.tpastream.com/static/js/sdk-v-0.7.7.js"` (last 0.7.x)
+* `sdk-v-0.8.0.js` (this version, pinned)
+* `sdk-v-0.7.7.js` (last 0.7.x, pinned)
+* `sdk.js` (floating pointer to the latest release; updates automatically when a new version ships)
 
-NPM package
-```javascript
+Pinned versions stay available indefinitely. See [Migrating from 0.7 to 0.8](./migration-0.7-to-0.8.md) for the breaking-change story before flipping the floating pointer in production.
 
-// Install with NPM
-npm i stream-connect-sdk
+### Via npm
 
+```bash
+npm install stream-connect-sdk
+```
+
+```js
 import StreamConnect from 'stream-connect-sdk';
 
 StreamConnect({
-  el: '#react-hook',
-  isDemo: true
+  el: '#sdk-hook',
+  employer: { vendor: 'internal', systemKey: 'EMP-123' },
+  user: { firstName: 'Joe', lastName: 'Sample', email: 'joe@example.com' },
+  apiToken: 'YOUR-SDK-TOKEN',
 });
 ```
 
-#### * Are required
+If you only want to try the UI without wiring credentials, drop everything except `el` and add `isDemo: true`:
 
-| Field                         |            Description                                                                                  | Type    | Example                                               | Default   |
-|-------------------------------|---------------------------------------------------------------------------------------------------------|---------|-------------------------------------------------------|-----------|
-| `el`*                         | A CSS selector for where you want the sdk to render: all items will render under this element           | String  | `el: '#react-hook'`                                   | N\A       |
-| `tenant`                      | The tenant configuration for this sdk instance. **Only needed if your token is configured to many tenants. Such a configuration will be made clear when TPAStream provides a token.** | Object  | `tenant: {}`                                          | `{}`      |
-| `tenant.vendor`               | The `code` for the specific vendor_tenant configured for this sdk-token. This is usually `internal`     | String  | `tenant: { vendor: 'internal' }`                      | `internal`|
-| `tenant.systemKey`            | The unique systemKey configured for your selected tenant on the selected vendor.                        | String  | `tenant: { systemKey: 'uniquekey' }`                  | N\A       |
-| `employer`*                   | The employer configuration for this sdk instance. Employers will be created if they don't exist already | Object  | `employer: {}`                                        | N\A       |
-| `employer.vendor`*            | The `code` for the specific vendor your employer is configured to.                                      | String  | `employer: { vendor: 'internal' }`                    | `internal`|
-| `employer.systemKey`*         | The unique systemKey configured for your selected employer on said vendor                               | String  | `employer: { systemKey: 'ekey' }`                     | N\A       |
-| `employer.name`               | Name of the employer. *Only needed if the employer doesn't already exist*                               | String  | `employer: { name: 'some-employer-name' }`            | N\A       |
-| `user`*                       | The user configuration. These are created automatically if they don't exist in our system. Think of users as employees going through and entering their payer credentials into our system. This is **not** an Implementors account on TPAStream (IE youremail@email.com). If you wish to set-up the SDK for the first time try using something like `youremail+testingsdk@email.com` in order to get the ball rolling.             | Object  | `user: {}`                                            | N\A       |
-| `user.firstName`*             | The user's first name                                                                                   | String  | `user: { firstName: 'Name' }`                         | N\A       |
-| `user.lastName`*              | The user's last name                                                                                    | String  | `user: { lastName: 'name' }`                          | N\A       |
-| `user.email`*                 | The user's email.                                                                                       | String  | `user: { email: 'email@email.com' }`                  | N\A       |
-| `user.memberSystemKey`        | A unique key for an implementer to identify for their system.                                           | String  | `user: { memberSystemKey: 'some-key' }`               | N\A       |
-| `user.phoneNumber`            | The user's phone number                                                                                 | String  | `user: { phoneNumber: '000-000-0000' }`               | N\A       |
-| `user.dateOfBirth`            | The user's date of birth                                                                                | String  | `user: { dateOfBirth: 'YYYY-MM-DD' }`                 | N\A       |
-| `sdkToken`*                   | The SDK Token. This has to be configured before-hand. It isn't a secret.                                | String  | `sdkToken: 'VeryLegitKey'`                            | N\A       |
-| `apiToken`*                   | The SDK token. Same value as `sdkToken`; pass either. If both are set, `apiToken` wins. Not a secret.   | String  | `apiToken: 'VeryLegitKey'`                            | N\A       |
-| `connectAccessToken`          | A generated token if advanced security is enabled. See [Connect Access Token](./connect-access-token.md). The 0.8 SDK also accepts a fresh `?accessToken=...` on the URL after a Patient Access API redirect; if present, it overrides this option for that load and is stripped from the URL via `history.replaceState`. | String  | `connectAccessToken: ''`                              | N\A       |
-| `includePayerBlogs`           | Enable optional payer updates blog on each enrollment form. Has some additional info about the payer.   | Boolean | `includePayerBlogs: false`                            | `false`   |
-| `theme`                       | Branding overrides applied as scoped CSS variables on the SDK root subtree. See [Theme](./theme.md).    | Object  | `theme: { primaryColor: '#2563eb' }`                  | `{}`      |
-| `theme.primaryColor`          | Hex color (e.g. `#2563eb`) used to recolor buttons, links, focus rings, and progress bars. Scoped to the SDK subtree; will not bleed into host-page CSS. | String  | `theme: { primaryColor: '#2563eb' }`                  | (built-in indigo) |
-| `enablePatientAccessAPI`      | **Default changed in 0.8 to `true`.** Enables Patient Access API payers (carriers that authenticate via a redirect to the carrier website rather than collecting credentials inline). With this flag on (the default), PAA-routed payers take the OAuth-popup branch; with it off, they fall through to the raw credentials form which exposes an `interoperability_refresh_token` field no real user can fill. See [Interop](./interop.md) and the [0.7→0.8 migration note](./migration-0.7-to-0.8.md#7-enablepatientaccessapi-default-flipped-to-true). | Boolean | `enablePatientAccessAPI: false` | `true` (was `false` in 0.7.x) |
-| `enablePatientAccessAPISinglePage` | Same as `enablePatientAccessAPI` but performs the redirect in the current tab instead of opening a new window. If true, takes precedence over `enablePatientAccessAPI`. | Boolean | `enablePatientAccessAPISinglePage: true` | `false` |
-| `enableInterop`               | **Deprecated** alias for `enablePatientAccessAPI`. Still works indefinitely; using it logs a one-time console warning. | Boolean | `enableInterop: true` | `false` |
-| `enableInteropSinglePage`     | **Deprecated** alias for `enablePatientAccessAPISinglePage`. Same behavior. | Boolean | `enableInteropSinglePage: true` | `false` |
-| `forceEndStep` | Skip directly to the end widget on load. Accepts the legacy boolean form (`true` -> end widget) and the explicit step-number form (`5` is the FinishedEasyEnroll step). The SDK also auto-applies this when the URL contains `?forceTPAStreamSdkEnd=1` (the flag is then stripped from the address bar). | Boolean \| Number | `forceEndStep: true` or `forceEndStep: 5` | `false` |
-| `entrySdkStateId` | Overrides the SDK-generated state id. Used to preserve SDK flow logs across a `webViewDelegation` round trip. Do not set otherwise. | String | `entrySdkStateId: 'somestateid'` | N\A |
-| `webViewDelegation` | Enables redirection delegation to a top-level webview hosting the SDK. The interop final redirect goes to `/patientaccessapi/sdk-interop-done-delegation/<string:sdk_state_id>/<int:ph_id>` for the host app to parse instead of `sdk_interop_done` or `window.location`. | Boolean | `webViewDelegation: true` | `false` |
-| `isDemo`                      | Tells the SDK not to work with real data; useful while iterating on styling. Demo mode cannot save or validate credentials. | Boolean | `isDemo: true`                                        | `false`   |
-| `realTimeVerification`        | Enables credential-validation UI feedback. Default is `true` (unchanged since 0.7.7). The 0.8 SDK uses a Server-Sent Events stream instead of the 0.7 polling loop, and validation renders in the non-blocking hero + corner-panel UI rather than blocking the carrier picker. Pass `false` to submit and immediately advance with no validation UI. | Boolean | `realTimeVerification: true`                          | `true`    |
-| `realtimeTimeout`             | **Deprecated in 0.8.** Was the polling-loop timeout in 0.7.x. The 0.8 SDK uses SSE with a server-side stream deadline (~10 minutes) and no longer reads this option. Accepted for back-compat but has no effect. | Number | `realtimeTimeout: 600`                          | n/a    |
-| `renderChoosePayer`           | Render the built-in choose-payer widget. If `false`, the widget is omitted and you must drive payer selection from the `doneChoosePayer` callback. | Boolean | `renderChoosePayer: false`                            | `true`    |
-| `renderPayerForm`             | Render the built-in credentials form. If `false`, drive it from `doneCreatedForm`. | Boolean | `renderPayerForm: false`                              | `true`    |
-| `renderEndWidget`             | Render the built-in end widget. If `false`, drive it from `doneEasyEnroll`. | Boolean | `renderEndWidget: false`                              | `true`    |
-| `userSchema`                  | **Changed in 0.8.** In 0.7.x this drove `react-jsonschema-form` UI-schema customization for the credentials form. `react-jsonschema-form` was removed in 0.8, so `userSchema` no longer affects rendering; the object is forwarded into the credential-submit payload for downstream consumers, and the SDK emits a one-time console warning when set. File an issue if you relied on UI-schema-driven extra fields. | Object  | `userSchema: {}`                                      | `{}`      |
-| `fixCredentials`              | **Deprecated in 0.8.** No longer needed: [fix-credentials mode](./fix-credentials.md) is now derived automatically from the presence of `connectAccessToken`. Accepted for back-compat and ignored; passing it logs a one-time console deprecation warning. | Boolean | `fixCredentials: true` | n/a |
-| `maxRetries`                  | **Deprecated in 0.8.** Was the retry count for the 0.7.x polling validation loop. The 0.8 SDK uses SSE with no client-side retry knob; this option is accepted for back-compat but has no effect. | Number  | `maxRetries: 3` | n/a |
-| `_overrideBaseUrl`            | Override the API base URL the SDK talks to. Used by the `/sdk-test` sandbox and integration tests; do not set in production. | String  | `_overrideBaseUrl: 'https://stevedev.tpastream.com'` | (`app.tpastream.com`) |
+```js
+StreamConnect({ el: '#sdk-hook', isDemo: true });
+```
+
+Demo mode renders the full UI against synthetic data; it cannot save or validate real credentials.
+
+### In a React app
+
+The SDK is shaped as a self-contained widget (it brings its own React internally and mounts into a DOM element you give it), so the canonical React integration is a thin `useEffect` wrapper:
+
+```jsx
+import { useEffect } from 'react';
+import StreamConnect from 'stream-connect-sdk';
+
+export function ConnectSDK({ employer, user, apiToken, ...opts }) {
+  useEffect(() => {
+    StreamConnect({
+      el: '#sdk-hook',
+      employer,
+      user,
+      apiToken,
+      ...opts,
+    });
+  }, []);
+  return <div id="sdk-hook" />;
+}
+```
+
+Then use it like any component:
+
+```jsx
+<ConnectSDK
+  employer={{ vendor: 'internal', systemKey: 'EMP-123' }}
+  user={{ firstName: 'Joe', lastName: 'Sample', email: 'joe@example.com' }}
+  apiToken={process.env.NEXT_PUBLIC_TPASTREAM_SDK_TOKEN}
+/>
+```
+
+A few things to know about this shape:
+
+* The SDK mounts its own React tree inside the `<div>`. Host-app React contexts, error boundaries, and refs don't compose into the SDK subtree.
+* Re-calling `StreamConnect()` against the same `el` unmounts the previous root cleanly (React 19 + WeakMap-backed root cache), so toggling identity props between renders is safe.
+* For SSR (Next.js / Remix), the `useEffect` runs client-side only; no special guarding needed.
+
+A first-class React package with `peerDependencies` on `react` (no second React tree, full composition) may follow in a future release.
+
+## Options reference
+
+`*` in the tables below marks fields you must supply.
+
+### Required
+
+| Field | Description | Type | Example |
+|---|---|---|---|
+| `el`* | A CSS selector for where you want the SDK to render. Everything renders under this element. | String | `el: '#sdk-hook'` |
+| `apiToken`* | Your SDK token. Configured ahead of time by TPAStream; not a secret (safe to ship in browser code). | String | `apiToken: 'YOUR-SDK-TOKEN'` |
+| `employer.vendor`* | The `code` for the vendor your employer is configured under. Usually `internal`. | String | `employer: { vendor: 'internal' }` |
+| `employer.systemKey`* | Unique systemKey for your employer on the selected vendor. | String | `employer: { systemKey: 'EMP-123' }` |
+| `employer.name` | Employer display name. Only required when the employer doesn't exist yet (the SDK auto-creates it). | String | `employer: { name: 'Acme Corp' }` |
+| `user`* | The user (member) connecting. Auto-created if not already in our system. Think "the employee entering their carrier credentials," not a TPAStream-staff account. | Object | see below |
+| `user.firstName`* | The user's first name. | String | `user: { firstName: 'Joe' }` |
+| `user.lastName`* | The user's last name. | String | `user: { lastName: 'Sample' }` |
+| `user.email`* | The user's email. | String | `user: { email: 'joe@example.com' }` |
+| `user.memberSystemKey` | Your system's stable ID for this user. Lets you cross-reference back from TPAStream webhooks. | String | `user: { memberSystemKey: 'mem_42' }` |
+| `user.phoneNumber` | The user's phone number. | String | `user: { phoneNumber: '555-555-5555' }` |
+| `user.dateOfBirth` | The user's date of birth, `YYYY-MM-DD`. | String | `user: { dateOfBirth: '1985-04-12' }` |
+| `tenant` | Only needed if your token is configured to multiple tenants. TPAStream will tell you when this applies. | Object | `tenant: { vendor: 'internal', systemKey: 'tenant-key' }` |
+
+### Theme
+
+| Field | Description | Type | Default |
+|---|---|---|---|
+| `theme.primaryColor` | CSS color (hex, rgb, named) used to recolor buttons, links, focus rings, and progress bars. Scoped to the SDK subtree via `.tpa-sdk-root`; won't bleed into host-page CSS. See [Theme](./theme.md). | String | built-in indigo |
+
+### Behavior
+
+| Field | Description | Type | Default |
+|---|---|---|---|
+| `isDemo` | Renders the SDK against synthetic data. Cannot save or validate real credentials. Useful while iterating on styling. | Boolean | `false` |
+| `realTimeVerification` | Show the credential-validation UI after submit. The 0.8 SDK uses an SSE stream (replaces the 0.7 polling loop) and renders validation in a non-blocking hero plus corner panel rather than blocking the carrier picker. Pass `false` to submit and advance immediately with no validation UI. | Boolean | `true` |
+| `enablePatientAccessAPI` | **Default flipped to `true` in 0.8.** PAA-routed payers (carriers that authenticate via redirect to the carrier's own site rather than collecting credentials inline) take the OAuth-popup branch. With this off, they fall through to a raw credentials form that exposes an `interoperability_refresh_token` field no real user can fill. See [Interop](./interop.md). | Boolean | `true` |
+| `enablePatientAccessAPISinglePage` | Same as `enablePatientAccessAPI` but performs the redirect in the current tab instead of a new window. Takes precedence over `enablePatientAccessAPI` when `true`. | Boolean | `false` |
+| `forceEndStep` | Skip directly to the end widget on load. Accepts the legacy boolean form (`true` → end widget) or an explicit step number (`5` is the `FinishedEasyEnroll` step). Auto-applied when the URL contains `?forceTPAStreamSdkEnd=1` (the flag is then stripped from the address bar). | Boolean or Number | `false` |
+| `includePayerBlogs` | Enable optional payer-updates blog on each enrollment form. Shows additional info about the carrier. | Boolean | `false` |
+| `connectAccessToken` | Required if [Connect Access Token](./connect-access-token.md) advanced security is enabled. The 0.8 SDK also accepts a fresh `?accessToken=...` on the URL after a Patient Access API redirect; if present, it overrides this option for that load and is stripped from the URL via `history.replaceState`. | String | unset |
+| `renderChoosePayer` | Render the built-in choose-payer widget. If `false`, you drive payer selection from the `doneChoosePayer` callback. | Boolean | `true` |
+| `renderPayerForm` | Render the built-in credentials form. If `false`, drive it from `doneCreatedForm`. | Boolean | `true` |
+| `renderEndWidget` | Render the built-in end widget. If `false`, drive it from `doneEasyEnroll`. | Boolean | `true` |
+
+### Lifecycle callbacks
+
+| Callback | Fires when |
+|---|---|
+| `doneGetSDK({ user, payers, tenant, employer })` | Initial SDK bootstrap completes. First callback in the flow. |
+| `doneSelectEnrollProcess()` | The select-enroll cards finish rendering (member-portal mode only; requires `connectAccessToken`). |
+| `doneFixCredentials()` | The user clicked the "Fix Credentials" card in member-portal mode. |
+| `doneChoosePayer({ choosePayer, usedPayers, dropdown, streamPayers })` | The choose-payer widget renders. With `renderChoosePayer: false`, this passes the props you need to drive payer selection yourself. |
+| `doneCreatedForm({ formJsonSchema, returnToChoosePayer, streamPayer, streamTenant, tenantTerms, toggleTermsOfUse, validateCreds })` | The credentials form renders. With `renderPayerForm: false`, drives a fully custom form. |
+| `doneTermsOfService()` | The user clicked the TPAStream Terms of Service link. |
+| `donePopUp()` | The user clicked the help (?) icon on the payer info card. |
+| `donePostCredentials({ params })` | The user submitted credentials and the SDK is posting them. Use to mirror the payload into your own backend. |
+| `doneRealTime()` | The realtime-validation widget rendered. Never fires when `realTimeVerification: false`. |
+| `doneEasyEnroll({ employer, payer, tenant, policyHolder, user, returnFlowFunction })` | Final callback; the enrollment is saved (possibly pending validation). |
+| `handleInitErrors(error)` | An init-configuration error happened before the SDK could mount. |
+| `handleFormErrors(error, { response, request, config })` | Credential submit failed. The SDK shows the error to the user; this lets you log it. |
+
+Each callback is documented in detail below.
+
+### Deprecated
+
+These still work and will continue to indefinitely; the SDK logs a one-time console warning when it sees them. Migrate at your leisure.
+
+| Field | Use instead | Notes |
+|---|---|---|
+| `sdkToken` | `apiToken` | Same value. If both are set, `apiToken` wins. |
+| `enableInterop` | `enablePatientAccessAPI` | Renamed in 0.8. |
+| `enableInteropSinglePage` | `enablePatientAccessAPISinglePage` | Renamed in 0.8. |
+| `fixCredentials` | (remove) | Member-portal mode is now derived automatically from the presence of `connectAccessToken`; the flag is ignored. |
+| `realtimeTimeout` | (remove) | Was the polling-loop timeout in 0.7.x. 0.8 uses SSE with a server-side stream deadline (~10 minutes). No-op. |
+| `maxRetries` | (remove) | Was the polling-loop retry count. 0.8 has no client-side retry knob. No-op. |
+| `userSchema` | (remove) | In 0.7.x this drove `react-jsonschema-form` UI-schema customization. `react-jsonschema-form` was replaced by React Hook Form + zod in 0.8, so `userSchema` no longer affects rendering. The object is forwarded into the credential-submit payload for downstream consumers. |
+
+### Internal / dev-only
+
+Don't set these in production code.
+
+| Field | What it's for |
+|---|---|
+| `_overrideBaseUrl` | Points the SDK at a different API host. Used by the `/sdk-test` sandbox on `stevedev.tpastream.com` and integration tests. |
+| `webViewDelegation` | Enables redirection-delegation to a top-level WebView host. The interop final redirect goes to `/patientaccessapi/sdk-interop-done-delegation/<state>/<ph>` for the host app to parse instead of `sdk_interop_done` or `window.location`. |
+| `entrySdkStateId` | Overrides the SDK-generated state id to preserve SDK flow logs across a `webViewDelegation` round trip. |
 
 ## Redirect query parameters (Patient Access API)
 
@@ -121,285 +197,290 @@ Both parameters are stripped from the URL via `history.replaceState` after the S
 
 > **Referrer caveat:** `replaceState` runs only after the SDK script has loaded and executed. Any resources, third-party scripts, or analytics beacons fetched *earlier* in the page lifecycle can still receive the token-bearing URL in the `Referer` header. For the full referrer-protection story (host-page `<meta name="referrer">` settings, CSP `Content-Security-Policy: referrer`, and the redirect-URL hygiene we recommend), see the Pre-SDK referrer caveat in [`connect-access-token.md`](./connect-access-token.md).
 
-You do not need to handle these parameters yourself; this section documents them so that integrators who inspect the URL or rely on `popstate` events know what to expect.
+You don't need to handle these parameters yourself; this section documents them so integrators who inspect the URL or rely on `popstate` events know what to expect.
 
-## Callbacks
-The main way an implementor will be interacting and modifying the `stream-connect-js-sdk` is via our various callbacks placed at key flowpoints of the SDK. In these callbacks the implementors are recommended to use `JavaScript` to style the various widgets as well as handle any additional custom logic which they deem necessary. These callbacks also include various amounts of information which can be helpful when trying to integrate fully with the TPAStream system.
+## Lifecycle callbacks (in detail)
+
+The main way an implementor interacts with the SDK is via callbacks fired at key flow points. See [SDK Flow](./sdk-flow.md) for a visual lifecycle diagram. Most callbacks pass useful data; some are pure styling hooks.
 
 ### `doneGetSDK`
-`doneGetSDK` is the first callback to be called in the SDK flow. It occurs when the system has finished its initial request to TPAStream systems.
 
-Data passed back -- These objects will have various information from the SDK. An Implementor might be concerned with any of the below.
+First callback in the SDK flow. Fires after the initial request to TPAStream completes.
+
+Data passed back:
+
 * `user`
-    * `email` -- You should see that this email is the same as the one you set in configuration. The SDK can interface with a TPAStream user to create policy_holders via email and token.
-    * `user_id` -- The unique identifier TPAStream uses for this user.
-    * `policy_holders` -- This will list out all of the policy_holders associated with the user. You can think of these as the saved credentials per carrier. Data passed back here will be limited.
-        * `payer_id` -- The ID for the specific payer these credentials exist for.
-        * `id` and `policy_holder_id` -- The unique identifier TPAStream uses for this set of credentials. If you implement any of the *TPAStream Webhooks* you will find this info useful for association.
+  * `email`: the same email you set in config.
+  * `user_id`: TPAStream's unique identifier for this user.
+  * `policy_holders`: all policy_holders already associated with the user (think "previously saved credentials per carrier"). Limited shape:
+    * `payer_id`
+    * `id` and `policy_holder_id`: same value, both surfaced for legacy reasons. Useful for matching webhook events back to the SDK session.
 * `tenant`
-    * `id` and `tenant_id`
-    * `name`
-    * `terms_of_use_message` -- This is configured at the tenant level. It allows specific terms of service messages per tenant. If you implement a custom widget you might be concerned with this data.
-* `payers` -- List of Payers. If implementing a custom choose-payer widget (`renderChoosePayer` is `false`) an implementor should use this data in the `doneChoosePayer.choosePayer` callback.
-    * `id` and `payer_id`
-    * `logo_url`
-    * `name`
+  * `id` and `tenant_id`
+  * `name`
+  * `terms_of_use_message`: configured at the tenant level. Use if you build a custom terms widget.
+* `payers`: list of `{id, payer_id, logo_url, name}`. Use when `renderChoosePayer: false`.
 * `employer`
-    * `id` and `employer_id`
-    * `name`
-    * `payers` -- The preferred payers to use on an employer. This can be configured in the TPAStream App.
-    * `show_all_payers_in_easy_enroll` -- When set `true` all payers supported in TPAStream will render as options in the widget. `true` is the default for an employer generated by the SDK
-    * `support_email_derived` -- Configured within the TPAStream App.
+  * `id` and `employer_id`
+  * `name`
+  * `payers`: the preferred payers configured for this employer.
+  * `show_all_payers_in_easy_enroll`: when `true`, all payers TPAStream supports render as options. Default `true` for an employer the SDK auto-creates.
+  * `support_email_derived`: configured in the TPAStream app.
 
-Example Usage:
-```javascript
+```js
 StreamConnect({
-  el: '#react-hook',
-  ...
+  el: '#sdk-hook',
+  // ...
   doneGetSDK: ({ user, payers, tenant, employer }) => {
-      // Do something with this data
+    // Mirror identity into analytics, etc.
   },
 });
 ```
 
 ### `doneSelectEnrollProcess`
-`doneSelectEnrollProcess` is fired right after doneGetSDK when the SDK is in member-portal mode (a `connectAccessToken` was supplied at init). This is primarily meant for styling the two buttons.
 
-Example Usage:
-```javascript
+Fires after `doneGetSDK` when the SDK is in member-portal mode (a `connectAccessToken` was supplied). Use for styling the two select-enroll cards.
+
+```js
 StreamConnect({
-  el: '#react-hook',
-  ...
+  el: '#sdk-hook',
+  // ...
   doneSelectEnrollProcess: () => {
-      // Do some styling
+    // Style the cards
   },
 });
 ```
 
 ### `doneFixCredentials`
-`doneFixCredentials` is fired after the Fix Credentials card is clicked in the select-enroll flow. This only fires in member-portal mode (when a `connectAccessToken` was supplied at init).
 
-Example Usage:
-```javascript
+Fires after the user clicks the Fix Credentials card in member-portal mode. Member-portal mode only.
+
+```js
 StreamConnect({
-  el: '#react-hook',
-  ...
+  el: '#sdk-hook',
+  // ...
   doneFixCredentials: () => {
-      // Do some styling
+    // Style the fix-credentials view
   },
 });
 ```
 
 ### `handleInitErrors`
-`handleInitErrors` is a callback which runs whenever there was a configuraiton error with the SDK. This configuration error will have a message attached to it explaining to an implementor what the problem with the configuration was. During this callback an implementor could add custom logic to handle custom messaging for the user who might be experiencing this error.
-Example Usage:
-```javascript
+
+Fires when the SDK can't initialize (missing `el`, missing required option, etc.). The error has a `message` you can surface to the user.
+
+```js
 StreamConnect({
-  el: '#react-hook',
-  ...
+  el: '#sdk-hook',
+  // ...
   handleInitErrors: (error) => {
-      // Do something with this data
+    console.error('TPAStream SDK init failed:', error.message);
   },
 });
 ```
 
 ### `doneChoosePayer`
-`doneChoosePayer` is the second callback to be called in the SDK flow. It occurs when the system has finished rendering the choose-payer widget. If the default widget is enabled then there are no parameters passed back into it. Instead implementors will be using this callback to style the default widget to their liking. This may take a little bit of effort depending on how your system looks and feels. It is best to worry about these changes while setting `isDemo` equal to `true` so that you can do so without worrying about creating data.
 
-If `renderChoosePayer: false` then this callback now passes back the params necessary for an implementor to create their own completely custom widget.
-* `choosePayer` -- This is a `javascript function`. Calling this will render the next widget. On a custom implementation you should have this as the select option. 
-    Accepted Properties below
-    * `payer` -- This is an `object` value. This object should be from `doneGetSDK.streamPayers`
-    * An example call would look like `choosePayer({ payer: streamPayers[some_choosen_index] })`
-* `usedPayers` -- This is a list of `payer_id`s. These ids are for payers which already have credentials associated to them.
-* `dropdown` -- If this value is `true` then the SDK will intend for a dropdown of all payers to be used. This value is the same as `doneGetSDK.employer.show_all_payers_in_easy_enroll`
-* `streamPayers` -- A list of all payers for this SDK instance based on employer. This will be the same as `doneGetSDK.streamPayers`
+Second callback in the SDK flow. Fires when the choose-payer widget renders.
 
-Example Usage:
-```javascript
+With `renderChoosePayer: true` (default), no parameters; use this callback purely for styling.
+
+With `renderChoosePayer: false`, the callback receives the props you need to drive your own picker:
+
+* `choosePayer({ payer })`: call this when the user picks a payer. The payer object should come from `streamPayers`. The SDK then renders the next step.
+* `usedPayers`: list of `payer_id`s that already have credentials.
+* `dropdown`: `true` if the SDK intends a full-payer dropdown (same as `employer.show_all_payers_in_easy_enroll` from `doneGetSDK`).
+* `streamPayers`: full list of payers for this SDK instance.
+
+```js
 StreamConnect({
-  el: '#react-hook',
-  ...
-  renderChoosePayer: false, // If this is true then there will be no data passed back to doneChoosePayer
+  el: '#sdk-hook',
+  // ...
+  renderChoosePayer: false,
   doneChoosePayer: ({ choosePayer, usedPayers, dropdown, streamPayers }) => {
-      const selectPayer = (payerId) => {
-          hideCustomWidget();
-          choosePayer({ payer: streamPayers.find(p => p.id === payerId)});
-      }
-      /* 
-        Here this function would do some stuff to render your custom widget.
-        selectPayer will be called when a payer is chosen by the user. That will in turn pass a payer ID back to the func.
-        That will in turn pick a payer from streamPayers and pass it to choose payer. When choose payer is called. The
-        Next SDK widget will render nested inside #react-hook
-      */
-      renderCustomWidget({ carriers: streamPayers, carriersWithCredentials: usedPayers, selectPayer: selectPayer })
+    const onPick = (payerId) => {
+      const payer = streamPayers.find((p) => p.id === payerId);
+      choosePayer({ payer });
+    };
+    renderMyCustomPicker({
+      payers: streamPayers,
+      withCredentials: usedPayers,
+      onPick,
+    });
   },
 });
 ```
 
 ### `doneCreatedForm`
-`doneCreatedForm` is the third callback to be called in the SDK flow. It occurs when the system finishes render the specific enrollment form for a carrier. This callback is purely used by the implementor for styling the form via JavaScript.
 
-If `renderPayerForm: false` then this callback now passes back the params necessary for an implementor to create their own completely custom widget.
-* `formJsonSchema` -- Provides a JS object which contains the configuration of the forms. Follows [Json Schema Form](https://github.com/json-schema-form) configuration.
-    * Within this schema you will find all the security questions for a given payer as well as lots of other values and requirements.
-* `returnToChoosePayer` -- When called it will reset the `el` which the SDK is hooked into and re-render the ChoosePayer widget.
-    * An example call would look like `returnToChoosePayer();`
-* `streamPayer` -- The carrier/payer object associated with the form and the credentials to be implemented.
-* `streamTenant` -- The tenant object the SDK and credentials it will be associated. This can be used to adjust text on your widget.
-* `tenantTerms` -- The custom terms of service configured by the Tenant.
-* `toggleTermsOfUse` -- renders the terms of use widget.
-    * An example call would look like `toggleTermsOfUse();`
-* `validateCreds` -- Function which will submit the values of the form and then begin the realtime validation process.
-    * `params` -- The values from the form to be submitted.
-    * An example call would look like `validateCreds({ params: formValues });`
+Third callback in the SDK flow. Fires when the credentials form renders for the chosen carrier.
 
-Example Usage:
-```javascript
+With `renderPayerForm: true` (default), this is a pure styling hook (no useful parameters).
+
+With `renderPayerForm: false`, you receive the props you need to drive a fully custom form:
+
+* `formJsonSchema`: the JSON Schema for this carrier's credential form, including security questions and field requirements. Drive your own renderer from this shape. (In 0.7.x the SDK rendered this with `react-jsonschema-form`; that library was removed in 0.8, but the schema itself is unchanged and still emitted on this callback for custom integrations.)
+* `returnToChoosePayer()`: reset to the carrier picker.
+* `streamPayer`: the carrier object for this form.
+* `streamTenant`: the tenant object. Useful for adjusting copy.
+* `tenantTerms`: custom terms-of-service configured by the tenant.
+* `toggleTermsOfUse()`: opens the Terms of Use overlay.
+* `validateCreds({ params })`: submit the form. Triggers the realtime-validation path.
+
+```js
 StreamConnect({
-  el: '#react-hook',
-  ...
-  doneCreatedForm: ({ formJsonSchema, returnToChoosePayer, streamPayer, streamTenant, tenantTerms, toggleTermsOfUse, validateCreds}) => {},
+  el: '#sdk-hook',
+  // ...
+  renderPayerForm: false,
+  doneCreatedForm: ({
+    formJsonSchema,
+    returnToChoosePayer,
+    streamPayer,
+    streamTenant,
+    tenantTerms,
+    toggleTermsOfUse,
+    validateCreds,
+  }) => {
+    // Render your form from formJsonSchema; on submit call validateCreds({ params }).
+  },
 });
 ```
 
 ### `doneTermsOfService`
-`doneTermsOfService` Callback occurs when the user clicks on the TPAStream terms of service link. This callback is purely used by the implementor for styling the form via JavaScript.
 
-Example Usage:
-```javascript
+Fires when the user clicks the TPAStream Terms of Service link. Pure styling hook.
+
+```js
 StreamConnect({
-  el: '#react-hook',
-  ...
-  doneTermsOfService: () => {
-      // Do some styling
-  },
+  el: '#sdk-hook',
+  // ...
+  doneTermsOfService: () => {},
 });
 ```
 
 ### `donePopUp`
-`donePopUp` Callback occurs when the user clicks on carrier pop-up. This callback is purely used by the implementor for styling the form via JavaScript.
 
-Example Usage:
-```javascript
+Fires when the user clicks the help (?) icon on the payer info card to open the carrier-specific help drawer. Pure styling hook.
+
+```js
 StreamConnect({
-  el: '#react-hook',
-  ...
-  donePopUp: () => {
-      // Do some styling
-  },
+  el: '#sdk-hook',
+  // ...
+  donePopUp: () => {},
 });
 ```
 
 ### `donePostCredentials`
-`donePostCredentials` fires when the user submits the credentials form and the SDK is posting the new creds. The callback gives implementors a chance to intercept the post payload (for example to persist to your own backend) before the SDK moves on to the validation step.
 
-These values vary by carrier. Common fields:
+Fires when the user submits the credentials form and the SDK is posting them. Use to mirror the payload into your own backend before the SDK advances to validation.
+
+Common payload fields (vary by carrier):
+
 * `params`
-    * `username`
-    * `password`
-    * `date_of_birth`
-    * `termsAndServices` and `accept` -- The user accepted the terms of use
-    * `payer_id`
-    * `tenants_accept` -- (List) Whether or not the user accepted the tenants terms of use
-    * `tenantAcknowledgement` -- Whether or not the user accepted the sending of their claims to the tenant.
-    * `security_question_first` -- First security question answer
-    * `security_question_first_choice`
-    * `security_question_second`
-    * `security_question_second_choice`
-    * `security_question_third`
-    * `security_question_third_choice`
+  * `username`
+  * `password`
+  * `date_of_birth`
+  * `termsAndServices` and `accept`: user accepted the TPAStream terms of use.
+  * `payer_id`
+  * `tenants_accept`: list of booleans, one per tenant the user accepted terms for.
+  * `tenantAcknowledgement`: user acknowledged the carrier-data-sharing notice.
+  * `security_question_first` / `security_question_first_choice`
+  * `security_question_second` / `security_question_second_choice`
+  * `security_question_third` / `security_question_third_choice`
 
-In 0.8, the credential-submit response also includes a `task_token` (a short-lived task-scoped JWT bound to the validation task) that the SDK uses internally to subscribe to the `/v3/sdk/progress/<task_id>/stream` SSE channel. Implementors do not need to handle the token themselves; the SDK uses it transparently. The token is audience-locked to `sdk:sse:progress`, valid for 10 minutes, and tied to the submitting user.
+In 0.8 the credential-submit response also includes a `task_token` (a short-lived task-scoped JWT bound to the validation task) that the SDK uses internally to subscribe to the `/v3/sdk/progress/<task_id>/stream` SSE channel. You don't need to handle the token; the SDK uses it transparently. The token is audience-locked to `sdk:sse:progress`, valid for 10 minutes, and tied to the submitting user.
 
-Example Usage:
-```javascript
+```js
 StreamConnect({
-  el: '#react-hook',
-  ...
+  el: '#sdk-hook',
+  // ...
   donePostCredentials: ({ params }) => {
-      // Save the params to your system
-      saveParams(params);
+    saveToYourBackend(params);
   },
 });
 ```
 
 ### `handleFormErrors`
-`handleFormErrors` Callback occurs when there was an issue submiting and saving the users credentials. While the SDK handles these errors and their presentation to the user, implementors might want additional info around these errors in order to better tune the SDK.
 
-This information can be obtuse. Its use may vary. Most implementors prefer to save this data in order to create info on what issues the users may have with saving.
+Fires when the credential submit fails. The SDK already shows the error to the user; this callback lets you log or instrument it.
+
 * `error`
 * `error_parts`
-    * `response`
-    * `request`
-    * `config`
+  * `response`
+  * `request`
+  * `config`
 
-Example Usage:
-```javascript
+```js
 StreamConnect({
-  el: '#react-hook',
-  ...
-  handleFormErrors: (error, {response, request, config}) => {
-      // Save the params to your system
-      console.log("Error Response -- Saving error to backend for logging purposes...");
-      console.log(response);
-      saveError(error);
+  el: '#sdk-hook',
+  // ...
+  handleFormErrors: (error, { response, request, config }) => {
+    console.error('Credential submit failed', error, response);
+    sendToYourLogger(error);
   },
 });
 ```
 
 ### `doneRealTime`
-`doneRealTime` Callback occurs when the system finishes rendering the realtime-validation widget. If `realTimeVerification: false` this callback is never hit. This call back is purely for styling purposes.
 
-Example Usage:
-```javascript
+Fires when the realtime-validation widget renders. Never fires when `realTimeVerification: false`. Pure styling hook.
+
+```js
 StreamConnect({
-  el: '#react-hook',
-  ...
-  doneRealTime: () => {
-      // Do some styling
-  },
+  el: '#sdk-hook',
+  // ...
+  doneRealTime: () => {},
 });
 ```
 
 ### `doneEasyEnroll`
-`doneEasyEnroll` This is the final callback of the SDK widget and it occurs when the system. There is a bunch of data dumped at the end which can be useful for an implementor when they are working the *TPAStream Webhooks*
 
-There are several properties passed back through this callback. Only a few may be applicable to an implementor.
+Final callback. Fires when enrollment is saved (possibly still pending validation).
+
+Properties:
+
 * `employer`
 * `payer`
 * `tenant`
 * `user`
-* `pending` -- The literal value the SDK is looking at to determine whether or not to show the pending page. If this is true the policyHolder is still pending.
-* `endingMessage` -- The specific ending message the SDK got from the backend to say to this user depending on their credentials status.
-* `policyHolder` -- The now saved policy_holder
-    * `policy_holder_id`
-    * `payer_id`
-    * `login_correction_message` -- This will be null unless the `login_problem !== 'valid' || login_problem !== null`
-    * `login_needs_correction` -- `true` or `false`. If `true` these credentials were found to be invalid via the realtime-validation engine.
-    * `login_problem` -- This can be equal to any of the following below. Each has a different meaning around the credentials
-        * `'valid'` -- The credentials are completely fine. Claims should start being collected shortly
-        * `'invalid'` -- The crawl engine found that these credentials are not valid for the carrier. The user will be prompted to re-enter valid credentials into the SDK.
-        * `'locked'` -- The crawl engine has identified that the carrier has locked this account for any number of reasons. This will require further action on the user's side in order to resolve.
-        * `'broken'` -- The crawl engine has identified some issue with this credential's account. This usually requires the carriers to fix some issue on their site for progress to occure
-        * `'needs_two_factor'` -- Support for two factor authentication for said payer is coming soon.
-        * `'incomplete'` -- The crawl engine has identified that the registration for the user's credentials on the carrier site is incomplete. This will require action on the user's side to resolve.
-        * `'inactive'` -- The user's account has been identified as inactive and thus will not be accessible to the crawler.
-        * `'sec_question'` -- The user's security questions appear to be incorrect. The user will be prompted to re-enter valid credentials
-        * `'wrong_secondary'` -- The user's account is configured to be using the wrong secondary method of authentication. This will prompt the user to update their account to use security questions.
-        * `null` -- The crawl engine is still trying to confirm the status of these credentials. This may take up to 24 hours depending on the carrier's site uptime.
+* `pending`: `true` if the policyHolder is still pending validation.
+* `endingMessage`: backend-provided message tailored to the credential status.
+* `policyHolder`: the saved policy_holder.
+  * `policy_holder_id`
+  * `payer_id`
+  * `login_correction_message`: only populated when `login_problem` is something other than `'valid'` or `null`.
+  * `login_needs_correction`: `true` if credentials were flagged invalid by realtime validation.
+  * `login_problem`: one of:
+    * `'valid'`: credentials are fine. Claims should start collecting shortly.
+    * `'invalid'`: the crawl engine confirmed bad credentials. The user will be prompted to re-enter them.
+    * `'locked'`: the carrier has locked this account. Requires user action on the carrier's site to resolve.
+    * `'broken'`: the crawl engine identified an issue requiring carrier-side fixes to make progress.
+    * `'needs_two_factor'`: the carrier requires 2FA on this login. The 0.8 SDK handles 2FA inline in the validation hero (method picker, code entry); customers who burn through 2FA prompts and reach a terminal failure end up here.
+    * `'incomplete'`: the user's carrier-site registration is incomplete. Requires user action to resolve.
+    * `'inactive'`: the account is inactive on the carrier site.
+    * `'sec_question'`: security-question answers were wrong. The user will be prompted to re-enter them.
+    * `'wrong_secondary'`: the account is configured with an unsupported secondary authentication method. The user will be prompted to switch the account to security questions.
+    * `null`: still being confirmed. Can take up to 24 hours depending on carrier-site uptime.
 
-If `renderEndWidget: true` then you will be given access to the following params as well.
-* `returnFlowFunction` This will restart the SDK engine or return the user to the payer form depending on if the credentials were valid or not.
-    * An example call of this function looks like `returnFlowFunction()`
+With `renderEndWidget: true` (default) you also get:
 
-Example Usage:
-```javascript
+* `returnFlowFunction()`: restart the SDK or return to the payer form, depending on whether credentials were valid.
+
+```js
 StreamConnect({
-  el: '#react-hook',
-  ...
-  doneEasyEnroll: ({ employer, payer, tenant, policyHolder, user, returnFlowFunction }) => {
-      // Do something with the data.
+  el: '#sdk-hook',
+  // ...
+  doneEasyEnroll: ({
+    employer,
+    payer,
+    tenant,
+    policyHolder,
+    user,
+    returnFlowFunction,
+  }) => {
+    if (policyHolder.login_problem === 'valid') {
+      analytics.track('enrollment_succeeded', { payer: payer.name });
+    }
   },
 });
 ```


### PR DESCRIPTION
Five improvements bundled, all in `docs/client-usage.md`. Mirrored to https://developers.tpastream.com/sdk/client-usage on the next docs build (the developer-docs site clones this repo at the latest tag at build time).

## 1. Minimal example first

Old opening showed a 30+-line kitchen-sink config block before the reader knew what any of the fields meant. New opening leads with the smallest thing that works (CDN + npm + React variants), then has a full-options reference further down. Adds an `isDemo: true` walk-through for browsing the UI without wiring real credentials.

## 2. Fix stale 0.8 content

- `formJsonSchema` description no longer references the removed `react-jsonschema-form` library. The schema itself is still emitted; only the renderer changed (now React Hook Form + zod).
- `login_problem: 'needs_two_factor'` no longer says "support coming soon". 0.8 actually shipped inline 2FA; clarified what reaching that terminal state means.
- `donePopUp` now reflects what it actually does (the payer-info help-icon click), not the vaguely-worded "carrier pop-up" description.
- The intent-named callbacks (`doneSelectEnrollProcess`, `doneFixCredentials`, `doneChoosePayer`, `doneCreatedForm`, `doneRealTime`) are documented as the public API rather than the positional `doneStep*` internals.

## 3. React integration example

The `useEffect` wrapper pattern most React customers reinvent themselves, written out with caveats about the SDK's standalone-widget shape (own React tree, host context doesn't bridge in, refs don't bridge out).

## 4. Reorganize the giant options table

Split into:

- Required
- Theme
- Behavior
- Lifecycle callbacks (overview, with details below)
- Deprecated (`sdkToken`, `enableInterop`, `enableInteropSinglePage`, `fixCredentials`, `realtimeTimeout`, `maxRetries`, `userSchema`)
- Internal / dev-only (`_overrideBaseUrl`, `webViewDelegation`, `entrySdkStateId`)

Each table fits a mobile viewport; readers can skip the Deprecated and Internal sections.

## 5. Quick wins

- Dropped the corporate opener ("We have decided that the best possible way...").
- Fixed the `sdkToken*` / `apiToken*` "both required" misdirection. One of these is required; `apiToken` is canonical, `sdkToken` is the legacy alias.
- Hoisted the `*` legend to immediately above the tables.
- Normalized heading hierarchy (h1 → h2 sections → h3 callbacks).
- Added a hero screenshot from the existing `flow-screenshots/` dir near the top.
- Added a prominent "Upgrading from 0.7?" callout right under the h1.

## Verification

Source for the field defaults and callback semantics was verified against:

- `assets/sdk/entries/sdk-core.tsx` (normalizeOptions, defaults, alias mapping)
- `assets/sdk/components/PayerInfo.tsx` (donePopUp firing point)
- `assets/sdk/types-init.ts` (option types still present in 0.8)

## Test plan

- [ ] CI green.
- [ ] After merge + next docs deploy, https://developers.tpastream.com/sdk/client-usage renders with the new structure.
- [ ] Screenshot embed (`flow-screenshots/choose-payer.png`) resolves on the live site.
- [ ] All cross-links to `migration-0.7-to-0.8.md`, `theme.md`, `interop.md`, `connect-access-token.md`, `sdk-flow.md` still resolve.