### PR TITLE
docs(quickstart): refresh Employer Key screenshot

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -153,12 +153,12 @@ your current email.
 When implementing the SDK all carrier credentials will be nested under an employer in TPAStream. This block will define which
 employer your are interested in.
 
-To get the Key for an existing employer go to the [Employers Page](https://app.tpastream.com/b/employers) in the TPAStream Admin portal. From there search up the desired employer. Then enter the details page of said employer. From there navigate to the **support** tab.
+To get the Key for an existing employer go to the [Employers Page](https://app.tpastream.com/d/employers) in the TPAStream Admin portal. From there search up the desired employer. Then enter the details page of said employer. From there open the **Support** tab.
 
 You will see a screen similar to this:
-![Employer Key Page](quickstart-screenshots/employer-key-page.png)
+![Employer Key Page](https://tpastream-public.s3.amazonaws.com/webapp-docs/employers/employer-key-page.png)
 
-You will see `Internal Key` as a section. Grab the key directly across from that and put it into the systemKey config option in the employer object. In this case it is highleted and called `testing-sdk`.
+The key field is labeled per-vendor — e.g. **Alegeus Key**, **OCA Key**, or simply **Key** depending on which integration the employer is attached to. Grab that value (in the screenshot it's `BBPGUIDE`) and put it into the `systemKey` config option in the employer object.
 
 
 # Step 6 -- Init


### PR DESCRIPTION
## Summary

Refresh the **Employer Key** screenshot in the quickstart guide.

- Image swapped to
  https://tpastream-public.s3.amazonaws.com/webapp-docs/employers/employer-key-page.png
  — captured via the new webapp screenshot pipeline in
  LakeEriePartners/stream#14381.
- Link to the Employers Page bumped from `/b/employers` (Backbone) to
  `/d/employers` (React). The Backbone admin is being retired and
  customers shouldn't be sent there.
- Surrounding text tightened: the old "you will see `Internal Key` as
  a section" was true on the pre-0.8 page but the current UI labels
  the field per-vendor (e.g. **Alegeus Key**, **OCA Key**), so the
  doc now describes that and points at the actual key value
  (`BBPGUIDE` in the captured shot).

## Out of scope

- A larger employer-page UX overhaul is on the roadmap; this shot
  will need a refresh once that ships, but the pipeline reduces the
  cost of that to a single capture+upload command.

## Test plan

- [ ] Reviewer opens the deployed preview, confirms the new image
      loads and the surrounding text matches what the UI shows.
