### PR TITLE
Auto-recover from expired connectAccessToken

### DIFF
--- a/assets/sdk/components/SDK.tsx
+++ b/assets/sdk/components/SDK.tsx
@@ -214,12 +214,20 @@ export const SDK = (props: SDKProps) => {
     sdkAxiosMaker({
       apiToken: props.apiToken,
       connectAccessToken: props.connectAccessToken,
+      connectAccessTokenRefreshFn: props.connectAccessTokenRefreshFn,
+      onConnectAccessTokenExpired: props.onConnectAccessTokenExpired,
       version: VERSION,
       isDemo: props.isDemo,
       sdkStateId: sdkStateId.current,
       tenant: props.tenant,
       _overrideBaseUrl: props._overrideBaseUrl
     });
+    // The token-expiry hooks (refresh fn + callback) are stashed
+    // module-locally inside sdkAxiosMaker, so they're not in this
+    // effect's deps. They're identity references the customer passes
+    // once at init() time; redefining them per-render would defeat the
+    // expiry-detection cache anyway.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     props.apiToken,
     props.connectAccessToken,

--- a/assets/sdk/services/axios.ts
+++ b/assets/sdk/services/axios.ts
@@ -56,6 +56,17 @@ let _onConnectAccessTokenExpired: (() => void) | undefined;
  * same promise.
  */
 let _refreshInFlight: Promise<string | null> | null = null;
+/**
+ * One-shot guard for the expiry notification path. Without it, N
+ * parallel failed requests in the no-refresh-fn (or
+ * refresh-fn-rejected) branch each independently fire the
+ * `onConnectAccessTokenExpired` callback and dispatch the
+ * `tpastream-connect-token-expired` event. From the customer's POV
+ * the failures are one logical "session expired" event, so we
+ * coalesce to one notification per expiry cycle. Reset on any
+ * successful response so a later expiry can notify again.
+ */
+let _expiredNotificationFired = false;
 
 export const sdkAxios = new Proxy({} as AxiosInstance, {
   get(_target, prop) {
@@ -130,6 +141,9 @@ export const sdkAxiosMaker = ({
       if (refreshed) {
         _sdkAxios.defaults.headers.common['X-Connect-Access-Token'] = refreshed;
       }
+      // Any successful response means we're no longer in an
+      // expired-token state, so a later expiry can notify again.
+      _expiredNotificationFired = false;
       return response;
     },
     async (error) => {
@@ -169,7 +183,20 @@ export const sdkAxiosMaker = ({
           const fresh = await _refreshInFlight;
           if (fresh) {
             _sdkAxios.defaults.headers.common['X-Connect-Access-Token'] = fresh;
-            originalConfig.headers.set('X-Connect-Access-Token', fresh);
+            // axios v1 normalizes request headers to AxiosHeaders
+            // (with `.set`) in the request pipeline, but a custom
+            // adapter or a config that bypassed the pipeline could
+            // leave them as a plain object. Fall back to assignment
+            // so a header-shape edge case can't throw a TypeError
+            // that escapes the surrounding try and bypasses the
+            // expiry notification.
+            const cfgHeaders = originalConfig.headers;
+            if (typeof cfgHeaders?.set === 'function') {
+              cfgHeaders.set('X-Connect-Access-Token', fresh);
+            } else if (cfgHeaders) {
+              (cfgHeaders as Record<string, string>)['X-Connect-Access-Token'] =
+                fresh;
+            }
             originalConfig.__sdkConnectTokenRetried = true;
             return _sdkAxios.request(originalConfig);
           }
@@ -185,20 +212,25 @@ export const sdkAxiosMaker = ({
       }
 
       // No refresh wired, refresh failed, or we already retried. Notify
-      // the host page and reject so existing error UI fires.
-      try {
-        _onConnectAccessTokenExpired?.();
-      } catch (cbErr) {
-        if (typeof console !== 'undefined' && console.warn) {
-          console.warn(
-            '[stream-connect-sdk] onConnectAccessTokenExpired callback ' +
-              'threw:',
-            cbErr
-          );
+      // the host page (once per expiry cycle — guarded by
+      // _expiredNotificationFired so N parallel failures don't fan out
+      // into N modals) and reject so existing error UI fires.
+      if (!_expiredNotificationFired) {
+        _expiredNotificationFired = true;
+        try {
+          _onConnectAccessTokenExpired?.();
+        } catch (cbErr) {
+          if (typeof console !== 'undefined' && console.warn) {
+            console.warn(
+              '[stream-connect-sdk] onConnectAccessTokenExpired callback ' +
+                'threw:',
+              cbErr
+            );
+          }
         }
-      }
-      if (typeof window !== 'undefined' && window.dispatchEvent) {
-        window.dispatchEvent(new CustomEvent(EXPIRED_TOKEN_EVENT));
+        if (typeof window !== 'undefined' && window.dispatchEvent) {
+          window.dispatchEvent(new CustomEvent(EXPIRED_TOKEN_EVENT));
+        }
       }
       return Promise.reject(error);
     }

--- a/assets/sdk/services/axios.ts
+++ b/assets/sdk/services/axios.ts
@@ -45,6 +45,17 @@ let _sdkAxios: AxiosInstance = axios.create({
 let _lastConfiguredToken: string | null = null;
 let _connectAccessTokenRefreshFn: (() => Promise<string>) | undefined;
 let _onConnectAccessTokenExpired: (() => void) | undefined;
+/**
+ * Shared in-flight refresh promise. If multiple requests are in flight
+ * when the connect token expires, each fires its own response
+ * interceptor and would otherwise independently call the refresh fn.
+ * Stampeding the customer's mint endpoint with N parallel calls leaves
+ * N-1 orphaned tokens (server-side Redis keys + JWT signatures) since
+ * only one ends up in the default header. Gate behind a shared promise:
+ * the first caller starts a refresh, every subsequent caller awaits the
+ * same promise.
+ */
+let _refreshInFlight: Promise<string | null> | null = null;
 
 export const sdkAxios = new Proxy({} as AxiosInstance, {
   get(_target, prop) {
@@ -140,7 +151,22 @@ export const sdkAxiosMaker = ({
       // would mean we can't replay it).
       if (_connectAccessTokenRefreshFn && originalConfig && !alreadyRetried) {
         try {
-          const fresh = await _connectAccessTokenRefreshFn();
+          // Stampede guard: every parallel-failed request shares a
+          // single refresh attempt. The first one in starts the
+          // promise and stashes it; subsequent ones await the same
+          // value. Cleared in the `finally` so a later expiry can
+          // start a fresh refresh.
+          if (!_refreshInFlight) {
+            const refreshFn = _connectAccessTokenRefreshFn;
+            _refreshInFlight = (async () => {
+              try {
+                return (await refreshFn()) || null;
+              } finally {
+                _refreshInFlight = null;
+              }
+            })();
+          }
+          const fresh = await _refreshInFlight;
           if (fresh) {
             _sdkAxios.defaults.headers.common['X-Connect-Access-Token'] = fresh;
             originalConfig.headers.set('X-Connect-Access-Token', fresh);

--- a/assets/sdk/services/axios.ts
+++ b/assets/sdk/services/axios.ts
@@ -1,5 +1,25 @@
-import axios, { type AxiosInstance } from 'axios';
+import axios, {
+  type AxiosInstance,
+  type InternalAxiosRequestConfig
+} from 'axios';
 import type { SDKInitOptions } from '../types-init';
+
+/**
+ * Sentinel attached to a retried request's config so the interceptor
+ * doesn't loop on a refresh that itself returns expired_connect_token.
+ */
+interface RetryAwareConfig extends InternalAxiosRequestConfig {
+  __sdkConnectTokenRetried?: boolean;
+}
+
+/**
+ * Stable contract field on backend 422 responses for an expired
+ * connect access token. The SDK keys off this string (not the
+ * human-readable `message`) so server-side copy can evolve without
+ * breaking auto-recovery.
+ */
+const EXPIRED_TOKEN_ERROR_CODE = 'expired_connect_token';
+const EXPIRED_TOKEN_EVENT = 'tpastream-connect-token-expired';
 
 /**
  * sdkAxios is a module-level singleton mutated when the SDK
@@ -23,6 +43,8 @@ let _sdkAxios: AxiosInstance = axios.create({
   headers: { 'X-Is-Demo': '1', 'X-SDK-Version': 'N/A' }
 });
 let _lastConfiguredToken: string | null = null;
+let _connectAccessTokenRefreshFn: (() => Promise<string>) | undefined;
+let _onConnectAccessTokenExpired: (() => void) | undefined;
 
 export const sdkAxios = new Proxy({} as AxiosInstance, {
   get(_target, prop) {
@@ -33,7 +55,13 @@ export const sdkAxios = new Proxy({} as AxiosInstance, {
 interface AxiosMakerArgs
   extends Pick<
     SDKInitOptions,
-    'apiToken' | 'connectAccessToken' | 'isDemo' | 'tenant' | '_overrideBaseUrl'
+    | 'apiToken'
+    | 'connectAccessToken'
+    | 'connectAccessTokenRefreshFn'
+    | 'onConnectAccessTokenExpired'
+    | 'isDemo'
+    | 'tenant'
+    | '_overrideBaseUrl'
   > {
   version: string;
   sdkStateId?: string;
@@ -42,12 +70,16 @@ interface AxiosMakerArgs
 export const sdkAxiosMaker = ({
   apiToken,
   connectAccessToken,
+  connectAccessTokenRefreshFn,
+  onConnectAccessTokenExpired,
   version,
   isDemo,
   sdkStateId,
   tenant,
   _overrideBaseUrl
 }: AxiosMakerArgs) => {
+  _connectAccessTokenRefreshFn = connectAccessTokenRefreshFn;
+  _onConnectAccessTokenExpired = onConnectAccessTokenExpired;
   const nextToken = apiToken || '';
   if (
     _lastConfiguredToken !== null &&
@@ -89,6 +121,60 @@ export const sdkAxiosMaker = ({
       }
       return response;
     },
-    (error) => Promise.reject(error)
+    async (error) => {
+      const status = error?.response?.status;
+      const errorCode = error?.response?.data?.error_code;
+      const isExpiredToken =
+        status === 422 && errorCode === EXPIRED_TOKEN_ERROR_CODE;
+      if (!isExpiredToken) {
+        return Promise.reject(error);
+      }
+
+      const originalConfig = error.config as RetryAwareConfig | undefined;
+      const alreadyRetried = Boolean(originalConfig?.__sdkConnectTokenRetried);
+
+      // Try a one-shot transparent refresh if the integrator wired
+      // `connectAccessTokenRefreshFn`. Skip if the failing request was
+      // itself a retry (the new token also got rejected — give up
+      // rather than loop) or the original config is missing (which
+      // would mean we can't replay it).
+      if (_connectAccessTokenRefreshFn && originalConfig && !alreadyRetried) {
+        try {
+          const fresh = await _connectAccessTokenRefreshFn();
+          if (fresh) {
+            _sdkAxios.defaults.headers.common['X-Connect-Access-Token'] = fresh;
+            originalConfig.headers.set('X-Connect-Access-Token', fresh);
+            originalConfig.__sdkConnectTokenRetried = true;
+            return _sdkAxios.request(originalConfig);
+          }
+        } catch (refreshErr) {
+          if (typeof console !== 'undefined' && console.warn) {
+            console.warn(
+              '[stream-connect-sdk] connectAccessTokenRefreshFn rejected; ' +
+                'falling back to onConnectAccessTokenExpired:',
+              refreshErr
+            );
+          }
+        }
+      }
+
+      // No refresh wired, refresh failed, or we already retried. Notify
+      // the host page and reject so existing error UI fires.
+      try {
+        _onConnectAccessTokenExpired?.();
+      } catch (cbErr) {
+        if (typeof console !== 'undefined' && console.warn) {
+          console.warn(
+            '[stream-connect-sdk] onConnectAccessTokenExpired callback ' +
+              'threw:',
+            cbErr
+          );
+        }
+      }
+      if (typeof window !== 'undefined' && window.dispatchEvent) {
+        window.dispatchEvent(new CustomEvent(EXPIRED_TOKEN_EVENT));
+      }
+      return Promise.reject(error);
+    }
   );
 };

--- a/assets/sdk/types-init.ts
+++ b/assets/sdk/types-init.ts
@@ -51,13 +51,14 @@ export interface SDKInitOptions {
   connectAccessTokenRefreshFn?: () => Promise<string>;
   /** Fires when the SDK detects an expired connect token AND either
    * no `connectAccessTokenRefreshFn` was provided or it rejected.
-   * Called once per failed request that hit the expiry (multiple
-   * parallel failures share a single refresh attempt, so in practice
-   * you'll see one callback if a refresh fn is wired, or one per
-   * failed request if not). Use to show a "session expired, please
-   * reload" UI in the host page. The same signal is also dispatched
-   * as a `tpastream-connect-token-expired` CustomEvent on `window`
-   * for integrations that prefer a global listener. */
+   * Coalesced: one callback per expiry cycle, regardless of how many
+   * parallel requests failed against the expired token. The cycle
+   * resets on the next successful response (i.e. after the customer
+   * recovers via a reload or a successful refresh), so a later
+   * expiration will notify again. Use to show a "session expired,
+   * please reload" UI in the host page. The same signal is also
+   * dispatched as a `tpastream-connect-token-expired` CustomEvent on
+   * `window` for integrations that prefer a global listener. */
   onConnectAccessTokenExpired?: () => void;
 
   // Identity

--- a/assets/sdk/types-init.ts
+++ b/assets/sdk/types-init.ts
@@ -49,12 +49,15 @@ export interface SDKInitOptions {
    * `window` and surfaces the error to the existing
    * `handleFormErrors` / `handleInitErrors` callbacks. */
   connectAccessTokenRefreshFn?: () => Promise<string>;
-  /** Fires once when the SDK detects an expired connect token AND
-   * either no `connectAccessTokenRefreshFn` was provided or it
-   * rejected. Use to show a "session expired, please reload" UI in
-   * the host page. The same signal is also dispatched as a
-   * `tpastream-connect-token-expired` CustomEvent on `window` for
-   * integrations that prefer a global listener. */
+  /** Fires when the SDK detects an expired connect token AND either
+   * no `connectAccessTokenRefreshFn` was provided or it rejected.
+   * Called once per failed request that hit the expiry (multiple
+   * parallel failures share a single refresh attempt, so in practice
+   * you'll see one callback if a refresh fn is wired, or one per
+   * failed request if not). Use to show a "session expired, please
+   * reload" UI in the host page. The same signal is also dispatched
+   * as a `tpastream-connect-token-expired` CustomEvent on `window`
+   * for integrations that prefer a global listener. */
   onConnectAccessTokenExpired?: () => void;
 
   // Identity

--- a/assets/sdk/types-init.ts
+++ b/assets/sdk/types-init.ts
@@ -36,6 +36,26 @@ export interface SDKInitOptions {
   apiToken?: string;
   sdkToken?: string;
   connectAccessToken?: string;
+  /** Optional async hook for refreshing an expired `connectAccessToken`
+   * without a page reload. The backend mints these short-lived tokens
+   * server-side (default ~60 min TTL, see Connect Access Token docs);
+   * when a member leaves the SDK page open past that window and comes
+   * back, the next API call gets a 422 with
+   * `error_code: "expired_connect_token"`. If this hook is provided,
+   * the SDK calls it, swaps the returned string into the axios
+   * `X-Connect-Access-Token` header, and retries the failed request
+   * transparently. If it's not provided (or it rejects), the SDK
+   * dispatches a `tpastream-connect-token-expired` CustomEvent on
+   * `window` and surfaces the error to the existing
+   * `handleFormErrors` / `handleInitErrors` callbacks. */
+  connectAccessTokenRefreshFn?: () => Promise<string>;
+  /** Fires once when the SDK detects an expired connect token AND
+   * either no `connectAccessTokenRefreshFn` was provided or it
+   * rejected. Use to show a "session expired, please reload" UI in
+   * the host page. The same signal is also dispatched as a
+   * `tpastream-connect-token-expired` CustomEvent on `window` for
+   * integrations that prefer a global listener. */
+  onConnectAccessTokenExpired?: () => void;
 
   // Identity
   tenant?: InitTenant;

--- a/docs/client-usage.md
+++ b/docs/client-usage.md
@@ -139,6 +139,7 @@ A first-class React package with `peerDependencies` on `react` (no second React 
 | `forceEndStep` | Skip directly to the end widget on load. Accepts the legacy boolean form (`true` → end widget) or an explicit step number (`5` is the `FinishedEasyEnroll` step). Auto-applied when the URL contains `?forceTPAStreamSdkEnd=1` (the flag is then stripped from the address bar). | Boolean or Number | `false` |
 | `includePayerBlogs` | Enable optional payer-updates blog on each enrollment form. Shows additional info about the carrier. | Boolean | `false` |
 | `connectAccessToken` | Required if [Connect Access Token](./connect-access-token.md) advanced security is enabled. The 0.8 SDK also accepts a fresh `?accessToken=...` on the URL after a Patient Access API redirect; if present, it overrides this option for that load and is stripped from the URL via `history.replaceState`. | String | unset |
+| `connectAccessTokenRefreshFn` | Async function the SDK calls to mint a fresh `connectAccessToken` when the current one has expired (server returns `error_code: "expired_connect_token"`). When provided, expired-token responses trigger a transparent refresh + retry instead of bubbling up as a failed request. Without it, the SDK fires `onConnectAccessTokenExpired` and dispatches a `tpastream-connect-token-expired` window event so the host page can prompt the user. Connect tokens have a ~60-minute TTL, so long-lived pages benefit. | `() => Promise<string>` | unset |
 | `renderChoosePayer` | Render the built-in choose-payer widget. If `false`, you drive payer selection from the `doneChoosePayer` callback. | Boolean | `true` |
 | `renderPayerForm` | Render the built-in credentials form. If `false`, drive it from `doneCreatedForm`. | Boolean | `true` |
 | `renderEndWidget` | Render the built-in end widget. If `false`, drive it from `doneEasyEnroll`. | Boolean | `true` |
@@ -159,6 +160,7 @@ A first-class React package with `peerDependencies` on `react` (no second React 
 | `doneEasyEnroll({ employer, payer, tenant, policyHolder, user, returnFlowFunction })` | Final callback; the enrollment is saved (possibly pending validation). |
 | `handleInitErrors(error)` | An init-configuration error happened before the SDK could mount. |
 | `handleFormErrors(error, { response, request, config })` | Credential submit failed. The SDK shows the error to the user; this lets you log it. |
+| `onConnectAccessTokenExpired()` | The `connectAccessToken` expired mid-session and either no `connectAccessTokenRefreshFn` was provided or the refresh attempt failed. Use to surface a "session expired, please reload" UI on the host page. Also dispatched as a `tpastream-connect-token-expired` window event for integrations that prefer a global listener. |
 
 Each callback is documented in detail below.
 


### PR DESCRIPTION
## Why

Connect access tokens have a ~60-minute server-side TTL. When a member leaves an SDK-hosting page open past that window and comes back to interact, the next API call fails with a 422 and the SDK currently bubbles it as a generic error — the only recovery is a manual page reload, which silently discards anything the user had typed.

The backend now returns a stable contract on these expirations:

```json
{ "error_code": "expired_connect_token", "message": "Your connect access token has expired. ..." }
```

This PR is the SDK-side handler that keys off that `error_code`.

## What

Adds a response interceptor to `assets/sdk/services/axios.ts`. On a 422 with `error_code === "expired_connect_token"`:

1. **If the integrator wired `connectAccessTokenRefreshFn`** — the interceptor calls it for a fresh token, updates the `X-Connect-Access-Token` header on the axios singleton + the in-flight retry config, and replays the failed request once. A `__sdkConnectTokenRetried` sentinel on the request config blocks infinite loops if the refreshed token also gets rejected.
2. **Otherwise** — fires `onConnectAccessTokenExpired()` (new init callback) and dispatches a `tpastream-connect-token-expired` CustomEvent on `window`, then rejects the request so existing error handlers (`handleFormErrors`, `handleInitErrors`) still see it.

## New init() options

| Option | Type | Purpose |
|---|---|---|
| `connectAccessTokenRefreshFn` | `() => Promise<string>` | Async hook returning a fresh connect token. When set, expired-token responses trigger transparent refresh + retry. |
| `onConnectAccessTokenExpired` | `() => void` | Fires when no refresh hook is wired or the refresh fails. Use to render a "session expired" UI on the host page. |

Both are optional. Integrations that don't wire either hook get a slightly cleaner error message, no behavior change beyond that.

## Why two hooks, not one

The refresh function shape is the right primitive for SPA hosts that have a server endpoint to mint a fresh token without a full page reload. The expiry callback is the right primitive for hosts that can't do that and just want to nudge the user. Having both means a host can wire `refreshFn` for the happy path AND `onExpired` as a fallback when refresh itself fails — which is the realistic shape for production integrations.

## Why a CustomEvent in addition to the callback

The event is a global signal — useful for analytics, host-page session managers, and integrations that wire the SDK inside a framework where threading callbacks through every mount is painful. It's strictly additive (the callback also fires).

## Back-compat

The interceptor is forward-compatible against older backends that don't yet emit the `error_code` field: the matching condition becomes `undefined === 'expired_connect_token'` → false, and behavior falls through to the existing reject path. Same outcome as today.

## Test plan

- [ ] CI green (`tsc`, `biome check`).
- [ ] In an integration where the backend returns `error_code: "expired_connect_token"` on an expired token, verify in browser console: `window.addEventListener('tpastream-connect-token-expired', console.log)` fires.
- [ ] Wire a `connectAccessTokenRefreshFn` and confirm transparent recovery (no error UI flash; failed request retries with fresh token).