### PR TITLE
Release 0.8.2: PAA OAuth toast, PH status view, 2FA fix, secure-context guard

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,89 @@ All notable changes to the `stream-connect-sdk` npm package. The
 companion React Native hook (`stream-connect-sdk-hook`) is on its own
 release line; see [`sdk-hook/docs/README.md`](./sdk-hook/docs/README.md).
 
+## 0.8.2
+
+### Fix: 2FA-required carriers no longer dead-end on a false "Connected"
+
+A member connecting a carrier that requires two-factor auth could land on
+a "Connected/finished" screen and never see the **verification-method
+picker or code entry** — the connection then silently failed when the
+carrier's 2FA prompt timed out unanswered. This happened with
+`realTimeVerification: false`: the SDK fell straight to the end widget and
+**never opened the progress stream**, so the `WAITING_FOR_METHOD_CHOICE`
+event had nothing listening.
+
+The fix keys the realtime/listening flow off the presence of a live
+validation task (the `taskId` + `taskToken` the credential submit returns)
+rather than off `realTimeVerification`. A live task means the backend is
+running an async validation that **may** require 2FA, and a 2FA-pending
+connection can never be "submit-and-trust" finished — the member has to
+act. The validation hero (method picker / code entry) and the SSE runner
+now mount whenever a validation is active, so 2FA is reachable even when
+the verification UI was opted out of. A page reload mid-2FA also resumes
+the live task now. First-time, never-submitted `realTimeVerification:
+false` users see no change.
+
+### Patient Access API (OAuth) return is a toast, not a full-page stop
+
+When a member finished connecting a carrier through its Patient Access
+API (the OAuth redirect flow), they previously landed on a full-page
+"Success!" end widget and had to click **"Add additional logins"** to
+do anything else. That dead-end click is gone.
+
+Both PAA variants now behave like the standard credential-submit flow:
+on a successful connection the SDK drops a self-dismissing **"Connected"
+card into the floating panel** and returns the member to the carrier
+picker so they can immediately add another carrier. This applies to the
+single-page redirect variant (which returns via
+`?forceTPAStreamSdkEnd=1`) and the popup variant (which polls the interop
+status). The single-page variant stashes the carrier name/logo across the
+redirect so the toast can name it.
+
+The explicit `forceEndStep` init option is unchanged — passing it still
+routes straight to the end widget. Only the URL-driven PAA return changed.
+When `realTimeVerification: false` (no floating panel), the PAA return
+keeps the legacy end-widget behavior.
+
+### Policy-holder status view + gated credential editing
+
+Tapping an already-connected carrier in the fix-credentials list now
+opens a **status view** first instead of dropping straight into the
+sign-in form. A healthy/connected carrier shows its connection status,
+last-synced time, masked username, and a **claim-sync summary** (claims
+synced + most recent claim date), and keeps the username/password hidden
+behind an explicit **"Update sign-in info"** button. PAA carriers show a
+**"Reconnect"** action instead. A carrier that genuinely needs attention
+(bad creds, etc.) still opens straight into the fix form. Adding a brand
+new carrier is unchanged.
+
+The claim-sync summary is fed by two new fields on the policy-holder SDK
+GET response (`claims_synced_count`, `most_recent_claim_date`); aggregate
+audit signals only — no per-claim provider / amount / diagnosis.
+
+### Refuse to initialize on insecure (plain HTTP) host pages
+
+`StreamConnect()` now checks `window.isSecureContext` at init and
+refuses to mount the SDK if the host page is served over plain HTTP
+from a non-loopback host. The browser-level secure-context check is
+true on HTTPS and on the loopback hosts (`localhost`, `127.0.0.1`,
+`[::1]`) — same set the new server-side CORS policy allows — so
+local development against `vite`, `webpack-dev-server`, etc. is
+unaffected.
+
+The previous behavior on a plain-HTTP page was a generic
+CORS-blocked error in the browser console on the first
+`/sdk-api/*` request, with no actionable explanation. The SDK now
+fails fast with a clear console error, calls the optional
+`handleInitErrors` callback with the same message, and links to
+the [origin-policy docs](https://developers.tpastream.com/connect/origin-policy)
+explaining the requirement and how to fix it.
+
+Members were never charged the network round-trip on a broken
+plain-HTTP integration in the first place, so the practical effect
+is shifting the error from "browser console mystery" to "init-time
+diagnostic that names the problem."
+
 ## 0.8.1
 
 ### Handle expired connectAccessToken without a confusing error

--- a/assets/sdk/components/InteroperabilityPayerForm.tsx
+++ b/assets/sdk/components/InteroperabilityPayerForm.tsx
@@ -127,6 +127,27 @@ export const InteroperabilityPayerForm = (
       await beginInterop({ email });
       if (enablePatientAccessAPISinglePage) {
         if (streamPayer.interoperability_authorization_url) {
+          // Stash the carrier so the post-redirect load can render a
+          // named "Connected" toast. The single-page flow navigates the
+          // whole tab to the carrier and back, wiping in-memory React
+          // state, so on return the SDK cold-inits with no streamPayer.
+          // sessionStorage survives the away-and-back navigation within
+          // the same tab; sdk-core reads + clears it. Wrapped in try/catch
+          // because Safari private mode throws on setItem, and a failed
+          // stash should never block the redirect — the toast just falls
+          // back to a generic label.
+          try {
+            window.sessionStorage.setItem(
+              'tpastream_interop_return_payer',
+              JSON.stringify({
+                id: streamPayer.id,
+                name: streamPayer.name,
+                logo_url: streamPayer.logo_url
+              })
+            );
+          } catch {
+            // non-fatal — proceed to the redirect without the stash
+          }
           window.location.replace(
             streamPayer.interoperability_authorization_url
           );

--- a/assets/sdk/components/PayerImages.tsx
+++ b/assets/sdk/components/PayerImages.tsx
@@ -1,87 +1,15 @@
 import { useMemo, useState } from 'react';
 import { useActiveValidations } from '../contexts/ActiveValidationsContext';
 import { SpinnerIcon } from '../icons';
+import type { StreamPayer, StreamPolicyHolderShort } from '../types';
 import {
-  CRITICAL_LOGIN_PROBLEMS,
-  type StreamPayer,
-  type StreamPolicyHolderShort,
-  VALID_LOGIN_PROBLEMS,
-  WARNING_LOGIN_PROBLEMS
-} from '../types';
-
-/**
- * Render-friendly mapping of login_problem enum values. Anything not
- * listed falls through to the raw key (uppercased) — fine for an
- * edge case the SDK might not know about, less ugly than displaying
- * the literal SQL value.
- */
-const LOGIN_PROBLEM_LABELS: Record<string, string> = {
-  invalid: 'Wrong username or password',
-  invalid_username_format: "Username format isn't accepted",
-  locked: 'Carrier account locked',
-  broken: 'Carrier account closed or moved',
-  invalid_interop_token: 'Connection expired',
-  incomplete: 'Missing some required info',
-  needs_two_factor: 'Two-factor verification needed',
-  sec_question: 'Security question needs an answer',
-  wrong_secondary: 'Wrong security answer',
-  mfa_carrier: 'Carrier sent a verification code',
-  migrating: 'Carrier is changing platforms'
-};
-
-const formatLastSynced = (iso: string): string => {
-  const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return '';
-  const diffMs = Date.now() - then;
-  const min = Math.round(diffMs / 60_000);
-  if (min < 1) return 'just now';
-  if (min < 60) return `${min} min ago`;
-  const hr = Math.round(min / 60);
-  if (hr < 24) return `${hr} hour${hr === 1 ? '' : 's'} ago`;
-  const d = Math.round(hr / 24);
-  if (d < 30) return `${d} day${d === 1 ? '' : 's'} ago`;
-  const mo = Math.round(d / 30);
-  return `${mo} month${mo === 1 ? '' : 's'} ago`;
-};
-
-type Severity = 'critical' | 'warning' | 'ok';
-
-const severityFor = (
-  loginProblem: string | null,
-  lastSyncIso: string | null | undefined
-): Severity => {
-  if (!loginProblem) return 'ok';
-  if (CRITICAL_LOGIN_PROBLEMS.has(loginProblem)) {
-    return 'critical';
-  }
-  if (WARNING_LOGIN_PROBLEMS.has(loginProblem)) {
-    // A recent successful sync downgrades warning to ok visually:
-    // the carrier is still pulling claims, the user just has an
-    // outstanding action item (often dismissable for that PH alone).
-    if (lastSyncIso) {
-      const ageMs = Date.now() - new Date(lastSyncIso).getTime();
-      if (ageMs < 7 * 24 * 60 * 60 * 1000) return 'ok';
-    }
-    return 'warning';
-  }
-  // Backend-accepted "this carrier is fine" enum values that aren't in
-  // the warning or critical sets (`valid`, `inactive`). Render as ok
-  // — they're explicit signals, not unknowns. (Most of the WARNING
-  // values are also in VALID_LOGIN_PROBLEMS because they're "valid
-  // creds but the user still needs to do something"; those got caught
-  // above and don't reach here.)
-  if (VALID_LOGIN_PROBLEMS.has(loginProblem)) {
-    return 'ok';
-  }
-  // An unknown non-null login_problem (e.g. a new enum value the
-  // backend added before the SDK was bumped) is treated as `warning`
-  // rather than `ok`. Showing "Action needed" with the raw problem
-  // string (via labelFor) is the safe fail-forward: a member who
-  // genuinely has a fixable issue won't be lulled into believing the
-  // connection is healthy. Pre-c5f9da0 this returned `ok` for unknowns,
-  // which hid real action items.
-  return 'warning';
-};
+  SEVERITY_BADGE_CLASSES,
+  SEVERITY_TILE_CLASSES,
+  type Severity,
+  formatLastSynced,
+  labelFor,
+  severityFor
+} from '../util/login-status';
 
 interface PayerImagesProps {
   streamPayers: StreamPayer[];
@@ -217,31 +145,6 @@ interface FixPayerImagesProps {
     dependent?: boolean;
   }) => void;
 }
-
-const SEVERITY_TILE_CLASSES: Record<Severity, string> = {
-  critical:
-    'tpa-bg-red-50 tpa-border-red-200 hover:tpa-shadow-card-hover tpa-cursor-pointer',
-  warning:
-    'tpa-bg-amber-50 tpa-border-amber-200 hover:tpa-shadow-card-hover tpa-cursor-pointer',
-  ok: 'tpa-bg-white tpa-border-slate-200 hover:tpa-shadow-card-hover tpa-cursor-pointer'
-};
-
-const SEVERITY_BADGE_CLASSES: Record<Severity, string> = {
-  critical: 'tpa-bg-red-100 tpa-text-red-800',
-  warning: 'tpa-bg-amber-100 tpa-text-amber-800',
-  ok: 'tpa-bg-emerald-100 tpa-text-emerald-800'
-};
-
-const labelFor = (
-  loginProblem: string | null,
-  severity: 'critical' | 'warning' | 'ok'
-): string => {
-  // Healthy PHs (no problem, OR a warning-class problem with a recent
-  // successful sync that downgraded it to 'ok') read as "Connected".
-  if (severity === 'ok') return 'Connected';
-  if (!loginProblem) return 'Action needed';
-  return LOGIN_PROBLEM_LABELS[loginProblem] || loginProblem.replace(/_/g, ' ');
-};
 
 export const FixPayerImages = ({
   policyHolders,

--- a/assets/sdk/components/PolicyHolderDetail.tsx
+++ b/assets/sdk/components/PolicyHolderDetail.tsx
@@ -1,0 +1,267 @@
+import { type ReactNode, useEffect, useState } from 'react';
+import { getPolicyHolder } from '../services/requests';
+import type { StreamPayer, StreamPolicyHolder } from '../types';
+import { BackButton } from '../ui/BackButton';
+import { Button } from '../ui/Button';
+import { Card } from '../ui/Card';
+import { Stack } from '../ui/Stack';
+import { Text, Title } from '../ui/Title';
+import {
+  SEVERITY_BADGE_CLASSES,
+  formatLastSynced,
+  labelFor,
+  severityFor
+} from '../util/login-status';
+
+interface PolicyHolderDetailProps {
+  /** The PH selected from the fix-credentials list. Carries enough to
+   * render the status header immediately (login_problem, username,
+   * last_successful_crawl_end); the claim-count summary is fetched
+   * lazily via getPolicyHolder. */
+  policyHolder: StreamPolicyHolder;
+  streamPayer: StreamPayer;
+  email: string;
+  employerId: number;
+  /** True when this carrier authenticates via PAA (OAuth redirect)
+   * rather than an inline credential form. Drives the edit-button copy
+   * ("Reconnect" vs "Update sign-in info") — the reveal still hands off
+   * to EnterCredentials, which routes to the InteroperabilityPayerForm
+   * for PAA payers. */
+  isInterop: boolean;
+  /** Back to the fix-credentials carrier list. */
+  returnToList: false | (() => void);
+  /** Renders the credential / reconnect form when the user opts to edit.
+   * `onBack` returns to this status view. Kept as a render-prop so all
+   * the EnterCredentials wiring stays in the SDK controller where the
+   * other props already live. */
+  renderEditForm: (onBack: () => void) => ReactNode;
+}
+
+const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec'
+];
+
+/** Format a bare ISO date (YYYY-MM-DD, the date_of_service the backend
+ * sends) without going through `new Date()`, which would interpret the
+ * string as UTC midnight and can render the previous day in a negative
+ * timezone. Parse the components directly. */
+const formatClaimDate = (iso: string | null | undefined): string | null => {
+  if (!iso) return null;
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+  if (!m) return null;
+  const [, year, mo, day] = m;
+  const monthName = MONTHS[Number(mo) - 1];
+  if (!monthName) return null;
+  return `${monthName} ${Number(day)}, ${year}`;
+};
+
+/** Show enough of the username to recognize the account without
+ * printing the whole identifier on a connected-account screen. */
+const maskUsername = (username: string): string => {
+  if (!username) return '';
+  // Mask short identifiers too (≤4 chars) — printing them whole defeats
+  // the privacy goal on exactly the most compact account IDs. Keep the
+  // first char as a recognition hint; a 1-char username is fully masked.
+  if (username.length <= 4) {
+    return username.length === 1
+      ? '*'
+      : `${username[0]}${'*'.repeat(username.length - 1)}`;
+  }
+  return `${username.slice(0, 4)}****`;
+};
+
+export const PolicyHolderDetail = (props: PolicyHolderDetailProps) => {
+  const { policyHolder, streamPayer, isInterop, returnToList, renderEditForm } =
+    props;
+
+  const severity = severityFor(
+    policyHolder.login_problem,
+    policyHolder.last_successful_crawl_end
+  );
+  const healthy = severity === 'ok';
+
+  // A broken / action-needed PH skips the status gate and opens straight
+  // into the fix form (the member came here to repair it). A healthy PH
+  // shows the read-only status first and gates the credential form behind
+  // an explicit edit action.
+  const [editing, setEditing] = useState(!healthy);
+
+  // Lazily enrich with the claim-sync summary. The list PH doesn't carry
+  // claims_synced_count / most_recent_claim_date; the single-PH GET does.
+  const [summary, setSummary] = useState<{
+    claimsSyncedCount: number | null;
+    mostRecentClaimDate: string | null;
+  } | null>(
+    // Seed from the passed PH if the controller already had the full
+    // shape (e.g. a fix-credentials reconnect that round-tripped GET).
+    policyHolder.claims_synced_count !== undefined
+      ? {
+          claimsSyncedCount: policyHolder.claims_synced_count ?? null,
+          mostRecentClaimDate: policyHolder.most_recent_claim_date ?? null
+        }
+      : null
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    // The summary only renders in the status-card view, so don't fetch it
+    // when we open straight into the edit form (a broken PH, where
+    // `editing` starts true). A healthy PH starts on the status card
+    // (`editing` false) and fetches here; if the member later hits "Update
+    // sign-in info" the fetch has already resolved, so there's no re-fetch
+    // to gate — `editing` is captured at mount and the effect keys on
+    // `policyHolder.id`.
+    if (editing) return;
+    // Only fetch when we don't already have the summary. The status
+    // header renders from the list PH meanwhile, so a slow / failed
+    // summary fetch never blocks the screen.
+    if (summary !== null) return;
+    getPolicyHolder({
+      policyHolderId: policyHolder.id,
+      email: props.email,
+      employerId: props.employerId
+    })
+      .then((full) => {
+        if (cancelled) return;
+        setSummary({
+          claimsSyncedCount: full.claims_synced_count ?? null,
+          mostRecentClaimDate: full.most_recent_claim_date ?? null
+        });
+      })
+      .catch(() => {
+        // Non-fatal — leave the summary hidden. The connection status is
+        // the primary signal; the claim counts are a nice-to-have audit
+        // aid, not a reason to error the whole screen.
+        if (!cancelled) {
+          setSummary({ claimsSyncedCount: null, mostRecentClaimDate: null });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [policyHolder.id]);
+
+  if (editing) {
+    // Healthy PH → back returns to this status view. Broken PH started in
+    // edit mode → back returns to the carrier list (its only sensible
+    // target), matching the pre-0.8.2 behavior.
+    return (
+      <>
+        {renderEditForm(
+          healthy
+            ? () => setEditing(false)
+            : (returnToList as () => void) || (() => {})
+        )}
+      </>
+    );
+  }
+
+  const badgeClass = SEVERITY_BADGE_CLASSES[severity];
+  const statusLabel = labelFor(policyHolder.login_problem, severity);
+  const lastSynced = policyHolder.last_successful_crawl_end
+    ? formatLastSynced(policyHolder.last_successful_crawl_end)
+    : null;
+  const claimsCount = summary?.claimsSyncedCount ?? null;
+  const recentClaim = formatClaimDate(summary?.mostRecentClaimDate);
+  const logo = streamPayer.logo_url || policyHolder.payer?.logo_url;
+  const name = streamPayer.name || policyHolder.payer?.name || 'Carrier';
+
+  return (
+    <Stack gap="md">
+      {returnToList && <BackButton onClick={returnToList as () => void} />}
+      <Card>
+        <Stack gap="lg">
+          <div className="tpa-flex tpa-items-center tpa-justify-between tpa-gap-3">
+            <div className="tpa-flex tpa-items-center tpa-gap-3 tpa-min-w-0">
+              {logo && (
+                <img
+                  src={logo}
+                  alt=""
+                  className="tpa-max-h-9 tpa-max-w-[120px] tpa-object-contain tpa-flex-shrink-0"
+                />
+              )}
+              <Title order={3}>{name}</Title>
+            </div>
+            <span
+              className={`tpa-text-xs tpa-font-medium tpa-rounded-full tpa-px-2 tpa-py-0.5 tpa-flex-shrink-0 ${badgeClass}`}
+            >
+              {statusLabel}
+            </span>
+          </div>
+
+          {/* Connection facts. Username is hidden for PAA carriers (no
+              inline credential — auth is the carrier OAuth grant). */}
+          <Stack gap="xs">
+            {!isInterop && policyHolder.username && (
+              <div className="tpa-flex tpa-justify-between tpa-text-sm tpa-gap-3">
+                <span className="tpa-text-slate-500">Username</span>
+                <span className="tpa-text-slate-900 tpa-truncate">
+                  {maskUsername(policyHolder.username)}
+                </span>
+              </div>
+            )}
+            {lastSynced && (
+              <div className="tpa-flex tpa-justify-between tpa-text-sm tpa-gap-3">
+                <span className="tpa-text-slate-500">Last synced</span>
+                <span className="tpa-text-slate-900">{lastSynced}</span>
+              </div>
+            )}
+          </Stack>
+
+          {/* Claim-sync summary — aggregate audit signals only. No
+              per-claim provider / amount / diagnosis is surfaced. */}
+          {(claimsCount !== null || recentClaim) && (
+            <div className="tpa-rounded-md tpa-bg-slate-50 tpa-p-3">
+              <Stack gap="xs">
+                {claimsCount !== null && (
+                  <div className="tpa-flex tpa-justify-between tpa-text-sm tpa-gap-3">
+                    <span className="tpa-text-slate-500">Claims synced</span>
+                    <span className="tpa-font-medium tpa-text-slate-900">
+                      {claimsCount.toLocaleString()}
+                    </span>
+                  </div>
+                )}
+                {recentClaim && (
+                  <div className="tpa-flex tpa-justify-between tpa-text-sm tpa-gap-3">
+                    <span className="tpa-text-slate-500">
+                      Most recent claim
+                    </span>
+                    <span className="tpa-font-medium tpa-text-slate-900">
+                      {recentClaim}
+                    </span>
+                  </div>
+                )}
+              </Stack>
+            </div>
+          )}
+
+          <Button
+            variant="secondary"
+            fullWidth
+            onClick={() => setEditing(true)}
+          >
+            {isInterop ? `Reconnect ${name}` : 'Update sign-in info'}
+          </Button>
+          {!isInterop && (
+            <Text size="xs" color="muted" className="tpa-text-center">
+              Your sign-in is connected. You only need to update it if your
+              carrier password changed.
+            </Text>
+          )}
+        </Stack>
+      </Card>
+    </Stack>
+  );
+};

--- a/assets/sdk/components/SDK.tsx
+++ b/assets/sdk/components/SDK.tsx
@@ -37,10 +37,11 @@ import { ChoosePayer } from './ChoosePayer';
 import { EnterCredentials } from './EnterCredentials';
 import { FinishedEasyEnroll } from './FinishedEasyEnroll';
 import { FixCredentials } from './FixCredentials';
+import { PolicyHolderDetail } from './PolicyHolderDetail';
 import { SelectEnrollProcess } from './SelectEnrollProcess';
 import { TermsOfUse } from './TermsOfUse';
 
-const VERSION = '0.8.1';
+const VERSION = '0.8.2';
 
 interface SDKProps extends SDKInitOptions {
   /** Computed inside the entry; passed in here so the controller
@@ -191,6 +192,11 @@ export const SDK = (props: SDKProps) => {
   useEffect(() => {
     if (!props.doneRealtime) return;
     for (const v of validations) {
+      // Skip synthetic PAA "Connected" toasts (showInteropSuccessToast):
+      // they're terminal cards with no SSE stream (empty taskToken), so
+      // announcing them as realtime validations would mislead integrators
+      // into thinking a stream started.
+      if (!v.taskToken) continue;
       if (!announcedRealtime.current.has(v.taskId)) {
         announcedRealtime.current.add(v.taskId);
         props.doneRealtime();
@@ -399,6 +405,44 @@ export const SDK = (props: SDKProps) => {
     ]
   );
 
+  // Push a one-off "Connected" card into the floating panel for a PAA
+  // (OAuth) carrier connection. Unlike a credential submit there's no
+  // celery task to stream — the carrier link is already confirmed — so
+  // we add a synthetic validation already in the terminal `success`
+  // state with `terminalConfirmed: true`. The ValidationStreamRunner
+  // skips any validation already success/failure/pending_async, so this
+  // never opens an SSE stream; the panel just renders it and
+  // auto-dismisses after the success hold. Used by both interop return
+  // paths (single-page redirect on init, and the popup poll-success
+  // branch in validateCreds) so OAuth connections get the same
+  // non-blocking toast as credential submits instead of a full-page
+  // end widget.
+  const showInteropSuccessToast = useCallback(
+    (args: {
+      policyHolderId?: number;
+      payer?: { id: number; name: string; logo_url: string } | null;
+      email?: string;
+    }) => {
+      const payer = args.payer ?? {
+        id: -1,
+        name: 'Your carrier',
+        logo_url: ''
+      };
+      addValidation({
+        policyHolderId: args.policyHolderId ?? -1,
+        // Unique per toast so concurrent / sequential interop successes
+        // don't collide on the context's id-keyed dedupe.
+        taskId: `interop-success-${payer.id}-${Date.now()}`,
+        taskToken: '',
+        payer,
+        email: args.email ?? '',
+        state: 'success',
+        terminalConfirmed: true
+      });
+    },
+    [addValidation]
+  );
+
   const validateCreds = useCallback(
     (args: {
       params: Record<string, unknown>;
@@ -420,39 +464,98 @@ export const SDK = (props: SDKProps) => {
       props.donePostCredentials?.({ params });
 
       if (interopPhId) {
+        // PAA (OAuth) popup flow just polled SUCCESS. In the default
+        // non-blocking flow, mirror the credential-submit behavior: drop
+        // a "Connected" toast into the floating panel and return the user
+        // to the carrier picker so they can add another carrier — no
+        // full-page end widget. We still fetch the PH to fire the legacy
+        // doneEasyEnroll with an accurate payload (and to feed the legacy
+        // submit-and-trust end widget when realTimeVerification is off).
+        const interopPayer = state.streamPayer
+          ? {
+              id: state.streamPayer.id,
+              name: state.streamPayer.name,
+              logo_url: state.streamPayer.logo_url
+            }
+          : null;
+        // Return step mirrors the credential-submit path: reconnecting an
+        // existing PH in fix mode goes back to the fix-credentials list
+        // (step 2); an add-new goes to the carrier picker (step 3).
+        const interopReturnStep = inFixMode && state.policyHolderId ? 2 : 3;
+        let fetchedPh: StreamPolicyHolder | null = null;
         getPolicyHolder({
           policyHolderId: interopPhId,
           email: state.streamUser.email,
           employerId: state.streamEmployer.id
         })
           .then((phData) => {
-            setState((prev) => ({
-              ...prev,
-              termsOfUse: false,
-              taskId: null,
-              taskToken: null,
+            fetchedPh = phData;
+            // Fire the legacy terminal callback so integrations relying on
+            // doneEasyEnroll keep getting a terminal event for PAA carriers.
+            props.doneEasyEnroll?.({
+              policyHolder: phData,
+              payer: state.streamPayer,
+              employer: state.streamEmployer,
+              tenant: state.streamTenant,
+              user: state.streamUser,
               credentialsValid: true,
-              policyHolderId: interopPhId,
-              streamPolicyHolder: phData,
-              step: 5
-            }));
+              pending: false
+            });
           })
           .catch(() => {
             // OAuth succeeded server-side but the post-success PH lookup
-            // failed. Advance to step 5 with credentialsValid still set
-            // (the upstream interop SUCCESS already confirmed the link)
-            // so the user reaches the end widget instead of stranding on
-            // the previous step. The end widget renders from the in-memory
-            // PH summary that was already fetched at init.
-            setState((prev) => ({
-              ...prev,
-              termsOfUse: false,
-              taskId: null,
-              taskToken: null,
-              credentialsValid: true,
+            // failed. Non-fatal — the upstream interop SUCCESS already
+            // confirmed the link, so we still show the toast / end widget.
+          })
+          .finally(() => {
+            if (!useNonBlockingValidation) {
+              // Legacy submit-and-trust (realTimeVerification: false):
+              // keep the full-page end widget.
+              setState((prev) => ({
+                ...prev,
+                termsOfUse: false,
+                taskId: null,
+                taskToken: null,
+                credentialsValid: true,
+                policyHolderId: interopPhId,
+                streamPolicyHolder: fetchedPh ?? prev.streamPolicyHolder,
+                step: 5
+              }));
+              return;
+            }
+            showInteropSuccessToast({
               policyHolderId: interopPhId,
-              step: 5
-            }));
+              payer: interopPayer,
+              email: state.streamUser?.email
+            });
+            // Refresh the carrier list so the just-connected PH shows up on
+            // the destination step instead of the stale init snapshot.
+            refreshUserPolicyHolders()
+              .then((user) => {
+                setState((prev) => ({
+                  ...prev,
+                  termsOfUse: false,
+                  taskId: null,
+                  taskToken: null,
+                  streamPayer: null,
+                  policyHolderId: null,
+                  streamPolicyHolder: null,
+                  streamUser: user ?? prev.streamUser,
+                  step: interopReturnStep
+                }));
+              })
+              .catch(() => {
+                setState((prev) => ({
+                  ...prev,
+                  termsOfUse: false,
+                  taskId: null,
+                  taskToken: null,
+                  streamPayer: null,
+                  policyHolderId: null,
+                  streamPolicyHolder: null,
+                  step: interopReturnStep
+                }));
+              });
           });
         return;
       }
@@ -486,19 +589,28 @@ export const SDK = (props: SDKProps) => {
         if (!state.streamUser || !state.streamEmployer || !policyHolderId)
           return;
 
-        // Non-blocking realtime path: push the validation into the
+        // Realtime / listening path: push the validation into the
         // floating panel and return the user to the picker step they
         // came from (Reconnect = step 2, Add new = step 3) so they can
         // start another validation in parallel. The floating panel +
         // the inline ActiveValidationsHero (2FA method picker / code
         // entry rendered inline in the hero card, no modal) own the
         // rest of the flow without taking over the screen.
-        if (
-          useNonBlockingValidation &&
-          taskId &&
-          taskToken &&
-          state.streamPayer
-        ) {
+        //
+        // Gate on the presence of a live validation task
+        // (taskId + taskToken), NOT on `useNonBlockingValidation`. A live
+        // task means the backend is running an async credential
+        // validation that MAY require 2FA — and a 2FA-pending connection
+        // can never be "submit-and-trust finished" (the member must pick
+        // a delivery method and enter a code, which only surfaces over the
+        // SSE stream). Previously `realTimeVerification: false` skipped
+        // this branch, fell straight to FinishedEasyEnroll, and never
+        // opened the progress stream, so 2FA carriers dead-ended on a
+        // false "Connected" screen. The realtime infra is now mounted
+        // whenever there's an active validation (see the render block), so
+        // the hero can surface the 2FA prompt even when the validation
+        // UI was opted out of.
+        if (taskId && taskToken && state.streamPayer) {
           addValidation({
             policyHolderId,
             taskId,
@@ -615,15 +727,19 @@ export const SDK = (props: SDKProps) => {
     [
       state.streamUser,
       state.streamEmployer,
+      state.streamTenant,
       state.policyHolderId,
       state.streamPayer,
       props.donePostCredentials,
       props.handleFormErrors,
+      props.doneEasyEnroll,
       props.realTimeVerification,
       props.isDemo,
       inFixMode,
       useNonBlockingValidation,
-      addValidation
+      addValidation,
+      showInteropSuccessToast,
+      refreshUserPolicyHolders
     ]
   );
 
@@ -693,7 +809,13 @@ export const SDK = (props: SDKProps) => {
         // floating panel + inline ActiveValidationsHero (2FA method
         // picker / code entry, no modal) handle the in-flight work in
         // parallel.
-        if (!restartFlow && useNonBlockingValidation) {
+        //
+        // Resume regardless of `useNonBlockingValidation`. A
+        // member who reloads the page mid-2FA (even with the validation
+        // UI opted out) must be able to re-enter the still-live task and
+        // finish the code entry; the realtime infra mounts whenever an
+        // active validation exists (see the render block).
+        if (!restartFlow) {
           for (const ph of user.policy_holders || []) {
             if (!ph.task_id || !ph.task_token) continue;
             const matchingPayer = payers.find((p) => p.id === ph.payer_id);
@@ -736,6 +858,40 @@ export const SDK = (props: SDKProps) => {
             step: target,
             credentialsValid: true
           }));
+          return;
+        }
+        if (props.interopReturn && !restartFlow) {
+          // The single-page PAA OAuth redirect just returned (sdk-core set
+          // this from `?forceTPAStreamSdkEnd=1`). In the default
+          // non-blocking flow, surface a "Connected" toast and land on the
+          // carrier picker (step 3) so the user can add another carrier —
+          // not the legacy full-page end widget. The just-connected PH
+          // shows up in the picker's used-carriers via the validations
+          // effect's user refresh. When non-blocking is disabled
+          // (realTimeVerification: false) there's no panel to host the
+          // toast, so fall back to the end widget.
+          if (useNonBlockingValidation) {
+            showInteropSuccessToast({
+              payer: props.interopReturnPayer ?? null,
+              email: user.email
+            });
+            setState((prev) => ({
+              ...prev,
+              loading: false,
+              step: 3,
+              termsOfUse: false,
+              streamPayer: null,
+              policyHolderId: null,
+              streamPolicyHolder: null
+            }));
+          } else {
+            setState((prev) => ({
+              ...prev,
+              loading: false,
+              step: 5,
+              credentialsValid: true
+            }));
+          }
           return;
         }
         if (inFixMode) {
@@ -837,9 +993,12 @@ export const SDK = (props: SDKProps) => {
       props.isDemo,
       props.doneGetSDK,
       props.forceEndStep,
+      props.interopReturn,
+      props.interopReturnPayer,
       inFixMode,
       useNonBlockingValidation,
       addValidation,
+      showInteropSuccessToast,
       setStep4,
       setStepConfigError
     ]
@@ -1001,16 +1160,21 @@ export const SDK = (props: SDKProps) => {
     }
     // Default: render the credentials form with the terms overlay
     // portaled on top. EnterCredentials stays mounted underneath so
-    // form state survives the round trip.
-    return (
+    // form state survives the round trip. Factored into a helper so the
+    // PolicyHolderDetail gate (below) can reveal the same form with its
+    // back button rewired to the status view instead of the carrier list.
+    const renderCredentialsForm = (
+      returnToStep2: false | (() => void),
+      returnToStep3: false | (() => void)
+    ) => (
       <>
         <EnterCredentials
-          streamPayer={state.streamPayer}
+          streamPayer={state.streamPayer!}
           streamPolicyHolder={state.streamPolicyHolder}
-          tenantTerms={state.streamTenant.terms_of_use}
+          tenantTerms={state.streamTenant!.terms_of_use}
           formData={state.formData}
           email={state.streamUser?.email || ''}
-          streamTenant={state.streamTenant}
+          streamTenant={state.streamTenant!}
           toggleTermsOfUse={toggleTermsOfUse}
           enableInterop={props.enableInterop}
           enableInteropSinglePage={props.enableInteropSinglePage}
@@ -1020,16 +1184,8 @@ export const SDK = (props: SDKProps) => {
           }
           includePayerBlogs={props.includePayerBlogs}
           userAddedUISchema={props.userSchema}
-          returnToStep3={
-            state.streamPayers &&
-            state.streamPayers.length > 1 &&
-            state.policyHolderId === null
-              ? setStep3
-              : false
-          }
-          returnToStep2={
-            inFixMode && state.policyHolderId !== null ? setStep2 : false
-          }
+          returnToStep3={returnToStep3}
+          returnToStep2={returnToStep2}
           validateCreds={validateCreds}
           doneStep4={props.doneStep4}
           donePopUp={props.donePopUp}
@@ -1037,6 +1193,50 @@ export const SDK = (props: SDKProps) => {
         {termsOverlay}
       </>
     );
+
+    const defaultReturnToStep3 =
+      state.streamPayers &&
+      state.streamPayers.length > 1 &&
+      state.policyHolderId === null
+        ? setStep3
+        : false;
+    const defaultReturnToStep2 =
+      inFixMode && state.policyHolderId !== null ? setStep2 : false;
+
+    // Status-first gate: when the user opened an EXISTING policy holder
+    // from the fix-credentials list, show its connection status (and a
+    // claim-sync summary) before the credential form. A healthy PH keeps
+    // its username/password hidden behind an explicit "Update sign-in
+    // info" action; a broken PH drops straight into the form. Adding a
+    // NEW carrier (no streamPolicyHolder) skips the gate entirely.
+    if (state.streamPolicyHolder) {
+      const usePAA =
+        !!(props.enablePatientAccessAPI ?? props.enableInterop) ||
+        !!(
+          props.enablePatientAccessAPISinglePage ??
+          props.enableInteropSinglePage
+        );
+      const isInterop =
+        usePAA && !!state.streamPayer.supports_interoperability_apis;
+      const returnToList = inFixMode ? setStep2 : setStep3;
+      return (
+        <PolicyHolderDetail
+          // Remount on a different PH so editing/summary state never
+          // carries over from a previously-opened carrier (the internal
+          // state is seeded from props at mount only).
+          key={state.streamPolicyHolder.id}
+          policyHolder={state.streamPolicyHolder}
+          streamPayer={state.streamPayer}
+          email={state.streamUser?.email || ''}
+          employerId={state.streamEmployer?.id ?? 0}
+          isInterop={isInterop}
+          returnToList={returnToList}
+          renderEditForm={(onBack) => renderCredentialsForm(onBack, false)}
+        />
+      );
+    }
+
+    return renderCredentialsForm(defaultReturnToStep2, defaultReturnToStep3);
   };
 
   const renderStep5_FinishedEasyEnroll = () => {
@@ -1115,6 +1315,18 @@ export const SDK = (props: SDKProps) => {
     return rendered ?? renderUnknownStep();
   };
 
+  // Mount the realtime infra when the non-blocking flow is on OR there's
+  // an active validation in flight. The second clause is the 2FA fix:
+  // even with `realTimeVerification: false`, a submitted credential can
+  // spawn a live validation task that needs 2FA, and the only way the
+  // member can complete it is the SSE-driven hero. Without mounting the
+  // runner the stream never opens (the carrier 2FA prompt times out
+  // unanswered) and without the hero there's nowhere to pick a method /
+  // enter the code. Gating on active validations keeps first-time,
+  // never-submitted realTimeVerification:false users exactly as before
+  // (no validation chrome) while making 2FA actually reachable for them.
+  const showValidationUi = useNonBlockingValidation || validations.length > 0;
+
   return (
     <>
       {/* Hero mounted at SDK level so a validation hitting 2FA while
@@ -1123,9 +1335,9 @@ export const SDK = (props: SDKProps) => {
           hero was inline-mounted in ChoosePayer / FixCredentials only,
           which left those other steps with a status-only panel and no
           way to enter the code. */}
-      {useNonBlockingValidation && <ActiveValidationsHero />}
+      {showValidationUi && <ActiveValidationsHero />}
       {renderWizard()}
-      {useNonBlockingValidation && state.streamUser && state.streamEmployer && (
+      {showValidationUi && state.streamUser && state.streamEmployer && (
         <ValidationStreamRunner
           email={state.streamUser.email}
           employerId={state.streamEmployer.id}
@@ -1163,7 +1375,7 @@ export const SDK = (props: SDKProps) => {
           }}
         />
       )}
-      {useNonBlockingValidation && <ActiveValidationsPanel />}
+      {showValidationUi && <ActiveValidationsPanel />}
     </>
   );
 };

--- a/assets/sdk/entries/sdk-core.tsx
+++ b/assets/sdk/entries/sdk-core.tsx
@@ -9,7 +9,38 @@ import type { SDKInitOptions } from '../types-init';
 // stylesheet so customers driving their own UI via the renderXxx
 // callbacks aren't forced to ship our ~50 KB of Tailwind output.
 
-const VERSION = '0.8.1';
+const VERSION = '0.8.2';
+
+const ORIGIN_POLICY_DOCS_URL =
+  'https://developers.tpastream.com/connect/origin-policy';
+
+// `window.isSecureContext` is the W3C primitive browsers use to gate
+// any API that handles sensitive data (WebAuthn, getUserMedia, service
+// workers). It is true on HTTPS pages and on the loopback hosts the
+// browser treats as secure — `localhost`, `127.0.0.1`, `[::1]`, file://,
+// chrome-extension:// — and false for plain `http://` everywhere else.
+//
+// We mirror that on the server (stream/security/sdk_cors.py) — the
+// `/sdk-api/*` CORS regex only echoes Access-Control-Allow-Origin for
+// HTTPS or loopback HTTP. So an integration loaded into a plain-HTTP
+// host page would hit a generic browser CORS-blocked error on the very
+// first API call, with no actionable explanation. Catch it here at
+// init() instead and report it clearly to the console + handleInitErrors
+// so the developer goes straight to the docs.
+const isSecureSDKContext = (): boolean => {
+  // SSR / non-browser harnesses (Jest with jsdom unset, etc.) can't
+  // be evaluated — fall through, the later `document.querySelector`
+  // path errors with its own message.
+  if (typeof window === 'undefined') return true;
+  // `isSecureContext` is also true for `file://` and extension pages,
+  // which are OUTSIDE the HTTPS/loopback set the `/sdk-api/*` CORS policy
+  // allows. Require an http(s) origin too, so those don't slip past this
+  // guard only to hit a generic CORS failure on the first API call.
+  const protocol = window.location.protocol;
+  return (
+    window.isSecureContext && (protocol === 'https:' || protocol === 'http:')
+  );
+};
 
 // Track one React root per container element. Some host pages call
 // StreamConnect() more than once against the same `el` (e.g. on a
@@ -132,7 +163,9 @@ const normalizeOptions = (opts: SDKInitOptions): SDKInitOptions => {
  *    the freshest value.
  *  - `?forceTPAStreamSdkEnd=1` — flag set by the redirect URL the SDK
  *    constructs in setStep4 when `enablePatientAccessAPISinglePage` is
- *    true. Tells this load to skip straight to the end widget.
+ *    true. Flags the single-page PAA OAuth return; the SDK shows a
+ *    "Connected" toast and lands on the carrier picker (see
+ *    `interopReturn` in SDK.tsx) rather than the full end widget.
  *
  * Both are stripped from the URL via history.replaceState so a refresh
  * doesn't re-trigger them AND the back button can't restore the
@@ -144,9 +177,14 @@ const normalizeOptions = (opts: SDKInitOptions): SDKInitOptions => {
 const consumeRedirectParams = (): {
   accessToken: string | null;
   shouldForceEnd: boolean;
+  interopReturnPayer: { id: number; name: string; logo_url: string } | null;
 } => {
   if (typeof window === 'undefined') {
-    return { accessToken: null, shouldForceEnd: false };
+    return {
+      accessToken: null,
+      shouldForceEnd: false,
+      interopReturnPayer: null
+    };
   }
   const search = new URLSearchParams(window.location.search);
   const accessToken = search.get('accessToken');
@@ -170,7 +208,44 @@ const consumeRedirectParams = (): {
     // (browser autofill, address bar, referrer leak, etc.).
     window.history.replaceState(null, '', newUrl);
   }
-  return { accessToken, shouldForceEnd };
+
+  // Pull (and clear) the carrier the single-page PAA flow stashed before
+  // redirecting to the carrier. Only consume it on an actual OAuth return
+  // (shouldForceEnd) so a stale stash from an abandoned attempt can't
+  // attach a wrong carrier name to an unrelated load. Always clear it
+  // when we're on a return so a refresh doesn't replay the toast.
+  let interopReturnPayer: {
+    id: number;
+    name: string;
+    logo_url: string;
+  } | null = null;
+  if (shouldForceEnd) {
+    try {
+      const raw = window.sessionStorage.getItem(
+        'tpastream_interop_return_payer'
+      );
+      window.sessionStorage.removeItem('tpastream_interop_return_payer');
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (
+          parsed &&
+          typeof parsed.id === 'number' &&
+          typeof parsed.name === 'string'
+        ) {
+          interopReturnPayer = {
+            id: parsed.id,
+            name: parsed.name,
+            logo_url: typeof parsed.logo_url === 'string' ? parsed.logo_url : ''
+          };
+        }
+      }
+    } catch {
+      // sessionStorage unavailable / malformed JSON — fall back to a
+      // generic toast label. Never let this block init.
+    }
+  }
+
+  return { accessToken, shouldForceEnd, interopReturnPayer };
 };
 
 const StreamConnect = (options: SDKInitOptions) => {
@@ -181,24 +256,49 @@ const StreamConnect = (options: SDKInitOptions) => {
     return;
   }
 
+  // Consume + strip the post-redirect params FIRST, before any early
+  // return. consumeRedirectParams() strips ?accessToken= /
+  // ?forceTPAStreamSdkEnd= from the URL via replaceState; we must do that
+  // even when we're about to refuse to mount on an insecure context, or a
+  // single-use access token would linger in the address bar / history.
+  const { accessToken, shouldForceEnd, interopReturnPayer } =
+    consumeRedirectParams();
+
+  if (!isSecureSDKContext()) {
+    const origin =
+      typeof window !== 'undefined' ? window.location.origin : '(unknown)';
+    const msg = `[stream-connect-sdk] init failed: host page must be served over HTTPS (or from http://localhost, http://127.0.0.1, or http://[::1] for local development). The current page origin ${origin} is insecure, and the SDK transmits member credentials — sending those over plain HTTP would expose them in transit. See ${ORIGIN_POLICY_DOCS_URL} for the fix.`;
+    console.error(msg);
+    options.handleInitErrors?.(new Error(msg));
+    return;
+  }
+
   console.log(`TPAStream Connect SDK v${VERSION}`);
 
   const normalized = normalizeOptions(options);
 
-  // Apply redirect-param overrides AFTER normalizeOptions so the
-  // accessToken from the URL wins over a stale connectAccessToken
-  // baked into the page.
-  const { accessToken, shouldForceEnd } = consumeRedirectParams();
+  // The accessToken from the URL wins over a stale connectAccessToken
+  // baked into the page. (Params were already consumed + stripped above,
+  // before the insecure-context guard.)
   if (accessToken) {
     normalized.connectAccessToken = accessToken;
   }
-  // Normalize forceEndStep to a number. Both the legacy 0.7.x boolean
-  // (`forceEndStep: true`) and the new explicit-step number form are
-  // accepted; truthy collapses to 5 (the FinishedEasyEnroll step) and
-  // the URL-side `forceTPAStreamSdkEnd` flag triggers the same path.
-  if (shouldForceEnd || normalized.forceEndStep) {
+  // Normalize an EXPLICIT forceEndStep init option to a number. The
+  // legacy 0.7.x boolean (`forceEndStep: true`) collapses to 5 (the
+  // FinishedEasyEnroll widget); a number is honored as-is. A customer
+  // passing this deliberately still gets the full end widget.
+  if (normalized.forceEndStep) {
     normalized.forceEndStep =
       typeof normalized.forceEndStep === 'number' ? normalized.forceEndStep : 5;
+  }
+  // The URL-side `?forceTPAStreamSdkEnd=1` flag — set by the single-page
+  // PAA OAuth redirect — no longer forces the full end widget. Instead
+  // it flags an "interop return": the SDK shows a "Connected" toast in
+  // the floating panel and lands the user back on the carrier picker so
+  // they can add another carrier without a button click. (0.8.2.)
+  if (shouldForceEnd) {
+    normalized.interopReturn = true;
+    normalized.interopReturnPayer = interopReturnPayer;
   }
 
   onDOMReady(() => {

--- a/assets/sdk/types-init.ts
+++ b/assets/sdk/types-init.ts
@@ -150,4 +150,22 @@ export interface SDKInitOptions {
 
   /** Override for tests + the /sdk-test sandbox. */
   _overrideBaseUrl?: string;
+
+  /** Internal — set by the entry (sdk-core) when the page loaded with
+   * `?forceTPAStreamSdkEnd=1`, i.e. the single-page PAA OAuth redirect
+   * just returned. Instead of the legacy full-page end widget, the SDK
+   * surfaces a "Connected" toast in the floating panel and lands the
+   * user back on the carrier picker so they can add another carrier.
+   * Not a public option; do not pass it yourself. */
+  interopReturn?: boolean;
+  /** Internal — the carrier the user just connected via the single-page
+   * PAA redirect, stashed in sessionStorage before the redirect and
+   * read back here so the return toast can name + logo the carrier.
+   * Null when the stash is missing (the toast falls back to a generic
+   * "Carrier connected"). */
+  interopReturnPayer?: {
+    id: number;
+    name: string;
+    logo_url: string;
+  } | null;
 }

--- a/assets/sdk/types.ts
+++ b/assets/sdk/types.ts
@@ -67,6 +67,16 @@ export interface StreamPolicyHolder extends StreamPolicyHolderShort {
   login_correction_message?: string | null;
   loginProblemIsValid: () => boolean;
   demo?: boolean;
+  /** Lifetime count of claims TPAStream has synced for this PH. Added
+   * to the policy_holder_sdk GET serializer in stream 0.8.2-era. Optional
+   * so an SDK built ahead of the backend still type-checks; the detail
+   * view hides the sync summary when it's absent. */
+  claims_synced_count?: number | null;
+  /** ISO date (date-of-service) of the most recent claim on file for
+   * this PH, or null if none. Surfaced as an audit anchor so a member
+   * can confirm their latest visit was captured. Deliberately the only
+   * per-claim datum exposed — no provider / amount / diagnosis. */
+  most_recent_claim_date?: string | null;
 }
 
 export interface StreamPayer {

--- a/assets/sdk/util/login-status.ts
+++ b/assets/sdk/util/login-status.ts
@@ -1,0 +1,117 @@
+import {
+  CRITICAL_LOGIN_PROBLEMS,
+  VALID_LOGIN_PROBLEMS,
+  WARNING_LOGIN_PROBLEMS
+} from '../types';
+
+/**
+ * Shared login-status presentation helpers. These map the backend
+ * `login_problem` enum (plus the most-recent successful sync time)
+ * onto the severity / label / relative-time vocabulary the SDK
+ * renders in both the fix-credentials carrier list (PayerImages) and
+ * the per-policy-holder status detail (PolicyHolderDetail). Kept in
+ * one place so the two surfaces can never drift on what counts as
+ * "Connected" vs "Action needed".
+ */
+
+/**
+ * Render-friendly mapping of login_problem enum values. Anything not
+ * listed falls through to the raw key (uppercased) — fine for an
+ * edge case the SDK might not know about, less ugly than displaying
+ * the literal SQL value.
+ */
+export const LOGIN_PROBLEM_LABELS: Record<string, string> = {
+  invalid: 'Wrong username or password',
+  invalid_username_format: "Username format isn't accepted",
+  locked: 'Carrier account locked',
+  broken: 'Carrier account closed or moved',
+  invalid_interop_token: 'Connection expired',
+  incomplete: 'Missing some required info',
+  needs_two_factor: 'Two-factor verification needed',
+  sec_question: 'Security question needs an answer',
+  wrong_secondary: 'Wrong security answer',
+  mfa_carrier: 'Carrier sent a verification code',
+  migrating: 'Carrier is changing platforms'
+};
+
+export const formatLastSynced = (iso: string): string => {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const diffMs = Date.now() - then;
+  // Floor, not round: a bucket should only advance once it's fully
+  // elapsed (31s is "just now", not "1 min ago"; 89m is "1 hour ago",
+  // not "2 hours ago").
+  const min = Math.floor(diffMs / 60_000);
+  if (min < 1) return 'just now';
+  if (min < 60) return `${min} min ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr} hour${hr === 1 ? '' : 's'} ago`;
+  const d = Math.floor(hr / 24);
+  if (d < 30) return `${d} day${d === 1 ? '' : 's'} ago`;
+  const mo = Math.floor(d / 30);
+  return `${mo} month${mo === 1 ? '' : 's'} ago`;
+};
+
+export type Severity = 'critical' | 'warning' | 'ok';
+
+export const severityFor = (
+  loginProblem: string | null,
+  lastSyncIso: string | null | undefined
+): Severity => {
+  if (!loginProblem) return 'ok';
+  if (CRITICAL_LOGIN_PROBLEMS.has(loginProblem)) {
+    return 'critical';
+  }
+  if (WARNING_LOGIN_PROBLEMS.has(loginProblem)) {
+    // A recent successful sync downgrades warning to ok visually:
+    // the carrier is still pulling claims, the user just has an
+    // outstanding action item (often dismissable for that PH alone).
+    if (lastSyncIso) {
+      const ageMs = Date.now() - new Date(lastSyncIso).getTime();
+      if (ageMs < 7 * 24 * 60 * 60 * 1000) return 'ok';
+    }
+    return 'warning';
+  }
+  // Backend-accepted "this carrier is fine" enum values that aren't in
+  // the warning or critical sets (`valid`, `inactive`). Render as ok
+  // — they're explicit signals, not unknowns. (Most of the WARNING
+  // values are also in VALID_LOGIN_PROBLEMS because they're "valid
+  // creds but the user still needs to do something"; those got caught
+  // above and don't reach here.)
+  if (VALID_LOGIN_PROBLEMS.has(loginProblem)) {
+    return 'ok';
+  }
+  // An unknown non-null login_problem (e.g. a new enum value the
+  // backend added before the SDK was bumped) is treated as `warning`
+  // rather than `ok`. Showing "Action needed" with the raw problem
+  // string (via labelFor) is the safe fail-forward: a member who
+  // genuinely has a fixable issue won't be lulled into believing the
+  // connection is healthy. Pre-c5f9da0 this returned `ok` for unknowns,
+  // which hid real action items.
+  return 'warning';
+};
+
+export const labelFor = (
+  loginProblem: string | null,
+  severity: Severity
+): string => {
+  // Healthy PHs (no problem, OR a warning-class problem with a recent
+  // successful sync that downgraded it to 'ok') read as "Connected".
+  if (severity === 'ok') return 'Connected';
+  if (!loginProblem) return 'Action needed';
+  return LOGIN_PROBLEM_LABELS[loginProblem] || loginProblem.replace(/_/g, ' ');
+};
+
+export const SEVERITY_BADGE_CLASSES: Record<Severity, string> = {
+  critical: 'tpa-bg-red-100 tpa-text-red-800',
+  warning: 'tpa-bg-amber-100 tpa-text-amber-800',
+  ok: 'tpa-bg-emerald-100 tpa-text-emerald-800'
+};
+
+export const SEVERITY_TILE_CLASSES: Record<Severity, string> = {
+  critical:
+    'tpa-bg-red-50 tpa-border-red-200 hover:tpa-shadow-card-hover tpa-cursor-pointer',
+  warning:
+    'tpa-bg-amber-50 tpa-border-amber-200 hover:tpa-shadow-card-hover tpa-cursor-pointer',
+  ok: 'tpa-bg-white tpa-border-slate-200 hover:tpa-shadow-card-hover tpa-cursor-pointer'
+};

--- a/docs/client-usage.md
+++ b/docs/client-usage.md
@@ -194,7 +194,7 @@ Don't set these in production code.
 When the Patient Access API flow returns the user from a carrier site back to the page hosting the SDK, the redirect URL can carry two query parameters that the 0.8 SDK reads automatically on init:
 
 * **`?accessToken=...`**: a fresh connect-access token minted by `app.tpastream.com` after the carrier redirect completes. The SDK reads it on load, uses it for the remainder of the session, and (regardless of whether `connectAccessToken` was already set in the init object) takes the URL value as the freshest. The token is single-use.
-* **`?forceTPAStreamSdkEnd=1`**: set by the redirect URL the SDK constructs when `enablePatientAccessAPISinglePage` is `true`. Tells this load to skip straight to the end widget instead of restarting at choose-payer.
+* **`?forceTPAStreamSdkEnd=1`**: set by the redirect URL the SDK constructs when `enablePatientAccessAPISinglePage` is `true`. Flags the OAuth return. As of 0.8.2 the SDK surfaces a self-dismissing "Connected" toast in the floating panel and lands the member on the carrier picker so they can add another carrier — it no longer forces the full-page end widget. (With `realTimeVerification: false` there's no panel, so it falls back to the end widget.) The explicit `forceEndStep` init option below is unaffected.
 
 Both parameters are stripped from the URL via `history.replaceState` after the SDK reads them. `replaceState` (not `pushState`) is used deliberately: the back button cannot restore the original URL, so the single-use access token cannot leak via history navigation or browser autofill.
 

--- a/docs/interop.md
+++ b/docs/interop.md
@@ -24,7 +24,7 @@ The legacy alias `enableInteropSinglePage` is also still accepted with the same 
 After the carrier redirect completes, the SDK reads two URL parameters automatically on load:
 
 * `?accessToken=...`: a fresh connect-access token minted by `app.tpastream.com`.
-* `?forceTPAStreamSdkEnd=1`: set in the single-page variant to tell the next load to skip straight to the end widget.
+* `?forceTPAStreamSdkEnd=1`: set in the single-page variant to flag the OAuth return. As of 0.8.2 the SDK shows a self-dismissing "Connected" toast in the floating panel and returns the member to the carrier picker (so they can add another carrier) rather than the full-page end widget. When `realTimeVerification: false` (no panel), it falls back to the end widget. The explicit `forceEndStep` init option is unaffected and still routes to the end widget.
 
 Both are stripped from the URL via `history.replaceState` so they cannot leak via browser history or autofill. See [Client Usage > Redirect query parameters](./client-usage.md#redirect-query-parameters-patient-access-api) for the full mechanics.
 

--- a/docs/migration-0.7-to-0.8.md
+++ b/docs/migration-0.7-to-0.8.md
@@ -91,6 +91,12 @@ If you deliberately want the legacy fallthrough behavior — e.g. you're doing c
 
 If you use `renderChoosePayer={false}` / `renderPayerForm={false}` / `renderEndWidget={false}` and drive those steps from `doneChoosePayer` / `doneCreatedForm` / `doneEasyEnroll`, the data passed into your callbacks is unchanged.
 
+### 9. Host page must be HTTPS (0.8.2)
+
+Starting in 0.8.2, `StreamConnect()` refuses to mount if the host page is served over plain `http://` from a non-loopback host. `localhost`, `127.0.0.1`, and `[::1]` are still allowed so local development is unaffected. Staging or internal hostnames served over plain HTTP are not.
+
+If you embed the SDK in a member-facing page that's currently on plain HTTP, that page must move to HTTPS before 0.8.x will mount. See the [Origin Policy doc](https://developers.tpastream.com/connect/origin-policy) for the full rules, the exact console error developers will see, and how to fix it.
+
 ## What you do NOT need to do
 
 - You do not need to add a `theme` option. The default appearance applies automatically.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-connect-sdk",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "A JavaScript SDK implementing TPAStream's Connect Platform",
   "scripts": {
     "build": "webpack --config webpack.prod-sdk.js --mode=production",


### PR DESCRIPTION
## stream-connect-sdk 0.8.2

Release sync for 0.8.2.

### Patient Access API (OAuth) return → toast + picker
Both PAA variants (single-page redirect + popup) drop a self-dismissing **"Connected"** card into the floating panel and return the member to the carrier picker, instead of a full-page end widget. The single-page variant carries the carrier across the redirect so the toast can name it. `forceEndStep` / `realTimeVerification: false` keep their prior end-widget behavior.

### Policy-holder status view + gated credential editing
Tapping an already-connected carrier opens a **status view** first (connection status, last-synced, masked username, and a claim-sync summary), with username/password gated behind an explicit **"Update sign-in info"** ("Reconnect" for PAA). Carriers needing attention open straight to the fix form; adding a new carrier is unchanged. Shared login-status helpers extracted to `util/login-status.ts`.

### Fix: 2FA-required carriers reach the verification step, not a false "Connected"
A carrier requiring two-factor auth could land on a "Connected/finished" screen and never present the verification-method picker / code entry. The realtime/listening flow now keys off the presence of a live validation task rather than `realTimeVerification`, so 2FA is reachable even when the validation UI is opted out of; an in-flight task resumes on reload.

### Refuse to mount on insecure (plain-HTTP) host pages
`StreamConnect()` checks the page is a secure context (HTTPS or loopback) at init and fails fast with a clear console error + `handleInitErrors` callback instead of a generic CORS error on the first API call. Redirect params are stripped before the bail so a single-use token can't linger; `file://` / extension pages are excluded.

### CI
Bumps the CodeQL workflow action v1 → v3 (v1 was deprecated and hard-fails).

## Verification
`tsc --noEmit`, `biome check`, and the production bundle build all pass.
