### PR TITLE
Accept policy_holder_id as an alias for id on policy-holder objects

### DIFF
--- a/assets/sdk/components/PolicyHolderDetail.tsx
+++ b/assets/sdk/components/PolicyHolderDetail.tsx
@@ -12,6 +12,7 @@ import {
   labelFor,
   severityFor
 } from '../util/login-status';
+import { resolvePolicyHolderId } from '../util/policy-holder-id';
 
 interface PolicyHolderDetailProps {
   /** The PH selected from the fix-credentials list. Carries enough to
@@ -127,8 +128,17 @@ export const PolicyHolderDetail = (props: PolicyHolderDetailProps) => {
     // header renders from the list PH meanwhile, so a slow / failed
     // summary fetch never blocks the screen.
     if (summary !== null) return;
+    // Never fetch without a resolvable id — `policy_holder/undefined`
+    // 404s at the routing layer. The controller normalizes ids before
+    // handing us the PH, but integrator-passed objects are outside our
+    // control; degrade to a summary-less status card instead.
+    const phId = resolvePolicyHolderId(policyHolder);
+    if (phId === null) {
+      setSummary({ claimsSyncedCount: null, mostRecentClaimDate: null });
+      return;
+    }
     getPolicyHolder({
-      policyHolderId: policyHolder.id,
+      policyHolderId: phId,
       email: props.email,
       employerId: props.employerId
     })

--- a/assets/sdk/components/SDK.tsx
+++ b/assets/sdk/components/SDK.tsx
@@ -31,6 +31,7 @@ import { Alert } from '../ui/Alert';
 import { Card } from '../ui/Card';
 import { Stack } from '../ui/Stack';
 import { Text, Title } from '../ui/Title';
+import { resolvePolicyHolderId } from '../util/policy-holder-id';
 import { ActiveValidationsHero } from './ActiveValidationsHero';
 import { ActiveValidationsPanel } from './ActiveValidationsPanel';
 import { ChoosePayer } from './ChoosePayer';
@@ -313,11 +314,22 @@ export const SDK = (props: SDKProps) => {
       }
       if (!state.streamUser || !state.streamEmployer) return;
 
+      // Normalize the id up front. Customer portals that drive the
+      // wizard via the step callbacks pass their own PH-shaped objects,
+      // which often carry `policy_holder_id` instead of `id` (the
+      // single-PH GET response has the same shape). Without this, the
+      // status view fetches `.../policy_holder/undefined` and a
+      // credential re-submit falls back from PUT to POST, stranding the
+      // original broken PH. See resolvePolicyHolderId.
+      const resolvedPhId = resolvePolicyHolderId(policyHolder);
       setState((prev) => ({
         ...prev,
         ...(policyHolder && {
-          streamPolicyHolder: policyHolder as unknown as StreamPolicyHolder,
-          policyHolderId: policyHolder.id
+          streamPolicyHolder: {
+            ...policyHolder,
+            id: resolvedPhId
+          } as unknown as StreamPolicyHolder,
+          policyHolderId: resolvedPhId
         })
       }));
 

--- a/assets/sdk/services/requests.ts
+++ b/assets/sdk/services/requests.ts
@@ -8,6 +8,7 @@ import {
   type ValidateCredsResponse
 } from '../types';
 import type { InitEmployer, InitUser } from '../types-init';
+import { resolvePolicyHolderId } from '../util/policy-holder-id';
 import { sdkAxios } from './axios';
 
 /**
@@ -139,6 +140,11 @@ export const getPolicyHolder = async ({
     { params: { employer_id: employerId, email } }
   );
   const ph = response.data.data as StreamPolicyHolder;
+  // The backend serializes `policy_holder_id` but not `id` on this
+  // endpoint. Backfill `id` so callers that store this object (the
+  // post-submit refresh paths keep it in state.streamPolicyHolder) can
+  // still build `.../policy_holder/<id>` URLs from it later.
+  ph.id = resolvePolicyHolderId(ph) ?? ph.id;
   // Attach the helper the legacy controller calls inline.
   // login_problem === null means "no problem at all" (clean account);
   // a non-null value names a specific issue and is only "valid" if it

--- a/assets/sdk/types.ts
+++ b/assets/sdk/types.ts
@@ -19,6 +19,14 @@ export interface StreamUser {
 
 export interface StreamPolicyHolderShort {
   id: number;
+  /** Alias for `id`. The backend's single-PH GET
+   * (`policy_holder_sdk/policy_holder/<id>`) serializes
+   * `policy_holder_id` but not `id`, and integrator-built PH objects
+   * (custom portals driving the wizard via the step callbacks) often
+   * carry only this field. Anywhere the SDK needs the numeric id it
+   * should go through `resolvePolicyHolderId`, which falls back to
+   * this alias. */
+  policy_holder_id?: number;
   payer_id: number;
   username: string;
   login_problem: string | null;

--- a/assets/sdk/util/policy-holder-id.ts
+++ b/assets/sdk/util/policy-holder-id.ts
@@ -1,0 +1,24 @@
+/** Resolve a policy holder's numeric id, accepting `policy_holder_id`
+ * as an alias for `id`.
+ *
+ * Two real-world sources produce PH objects without `id`:
+ * - The backend's single-PH GET (`policy_holder_sdk/policy_holder/<id>`)
+ *   serializes `policy_holder_id` but not `id`, so anything that
+ *   round-trips that response (including our own post-submit refresh)
+ *   loses the `id` field.
+ * - Customer portals that drive the wizard programmatically via the
+ *   step callbacks (`doneStep2` → `choosePolicyHolder`) and pass their
+ *   own PH-shaped objects keyed on `policy_holder_id`.
+ *
+ * Without the fallback, `policyHolder.id` interpolates as the literal
+ * string "undefined" into request URLs (`.../policy_holder/undefined`),
+ * which 404s at the routing layer — and worse, a credential submit
+ * falls back from PUT (update-in-place) to POST (create), stranding
+ * the original broken PH. Verified in production traffic 2026-07.
+ */
+export const resolvePolicyHolderId = (
+  ph:
+    | { id?: number | null; policy_holder_id?: number | null }
+    | null
+    | undefined
+): number | null => ph?.id ?? ph?.policy_holder_id ?? null;


### PR DESCRIPTION
## What

`resolvePolicyHolderId()` accepts `policy_holder_id` as an alias for `id` on policy-holder objects, applied at the three boundaries where an id-less PH can enter the SDK:

- **`setStep4`** normalizes integrator-passed `policyHolder` objects before storing them in state
- **`getPolicyHolder()`** backfills `id` on the single-PH GET response (the backend serializes `policy_holder_id` but not `id` on that endpoint), so the post-submit refresh paths keep a usable object in state
- **`PolicyHolderDetail`** degrades to a summary-less status card instead of fetching when no id resolves

`StreamPolicyHolderShort` gains an optional `policy_holder_id` field documenting the alias.

## Why

A customer portal drives the wizard programmatically via the step callbacks (`doneStep2` → `choosePolicyHolder`) and passes PH objects carrying `policy_holder_id` but no `id`. Verified in production traffic (nginx ES index, correlated with `X-SDK-Version` from SDKLogger):

- Starting exactly with their 0.8.2 upgrade (staging 2026-07-06, prod 2026-07-07), the new status view fetched `.../policy_holder/undefined` — a routing 404 on the CORS preflight, ~50/week across 18 member IPs. Silent to the member (the summary fetch is non-fatal) but the claim-sync summary never rendered.
- Worse and predating 0.8.2: with `policyHolder.id` undefined, a credential re-submit falls back from PUT (update-in-place) to POST (create). The backend POST upserts on (username, payer, user), so same-username fixes work — but a changed username creates a new PH and strands the original broken one as permanently "Invalid". That tenant shows 0 PUTs in 30 days (every other SDK customer PUTs routinely) and 842 duplicate member+payer PH groups.

The one-line fix on the integrator side is to include `id`, but any integrator round-tripping our own single-PH GET response hits the same trap, so the SDK should tolerate the alias.

## Testing

- `npm test` (biome + tsc) green
- No behavior change for objects that already carry `id`: `resolvePolicyHolderId` prefers `id` and only falls back when it's null/undefined
