### PR TITLE
Release 0.8.3: fix DOB-carrier enrollment (date_of_birth nulled on submit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to the `stream-connect-sdk` npm package. The
 companion React Native hook (`stream-connect-sdk-hook`) is on its own
 release line; see [`sdk-hook/docs/README.md`](./sdk-hook/docs/README.md).
 
+## 0.8.3
+
+### Fix: carriers that ask for Date of Birth could never be connected
+
+A member connecting a carrier whose credential form includes a **Date of
+Birth** field — Medical Mutual and SimplePay Health — could not complete
+enrollment. Whatever they typed was discarded before the request left the
+browser, the backend rejected the submission as missing a required field
+(HTTP 422), and the form came back with a red validation error. No input
+format worked, because the value never reached the server at all.
+
+The credential payload spread the carrier's form values first and then
+re-pinned a handful of SDK-controlled fields on top. One of those was
+`date_of_birth: values.dateOfBirth || null` — camelCase, which no carrier
+schema emits — so it always evaluated to `null` and overwrote the real
+value. The line was inherited from 0.7.x, where the spread order was
+reversed and the member's value won; 0.8.0 inverted that order (so carrier
+schemas can't clobber `payer_id` / `accept` / `tenants_accept`) and turned a
+dead line into a data-destroying one. The re-pin is gone; `payer_id` and the
+consent fields are still protected.
+
+Date fields also render as a native date input now. Carrier schemas mark
+them `{"type": "string", "format": "date"}`, which 0.8.x rendered as a bare
+text box with no format hint even though the backend only accepts ISO
+`YYYY-MM-DD`. The date input always produces ISO, so there is nothing left
+to guess.
+
+The React Native hook (`stream-connect-sdk-hook`) kept the 0.7.x spread
+order and was never affected.
+
 ## 0.8.2
 
 ### Fix: 2FA-required carriers no longer dead-end on a false "Connected"

--- a/assets/sdk/components/EnterCredentials.tsx
+++ b/assets/sdk/components/EnterCredentials.tsx
@@ -110,7 +110,7 @@ interface FormState {
   fields: Array<{
     key: string;
     title: string;
-    type: 'text' | 'password' | 'select' | 'checkbox';
+    type: 'text' | 'password' | 'select' | 'checkbox' | 'date';
     options?: string[];
     placeholder?: string;
   }>;
@@ -150,6 +150,14 @@ const buildFormFromOnboardSchema = (payer: StreamPayer): FormState => {
       type = 'select';
     } else if (p?.type === 'boolean') {
       type = 'checkbox';
+    } else if (p?.format === 'date') {
+      // Carrier schemas emit `{type: 'string', format: 'date'}` for DOB
+      // fields (Medical Mutual, SimplePay Health). Render a native date
+      // input so the submitted value is always ISO `YYYY-MM-DD`, which
+      // is the only format the backend's WTForms DateField parses. As a
+      // free-text box the member has to guess the format, and every
+      // guess but ISO is rejected server-side with a 422.
+      type = 'date';
     }
 
     fields.push({
@@ -344,7 +352,15 @@ export const EnterCredentials = (props: EnterCredentialsProps) => {
       ...values,
       username: values.username,
       password: values.password,
-      date_of_birth: values.dateOfBirth || null,
+      // NOTE: do not re-pin `date_of_birth` here. Carrier form values are
+      // keyed by their JSON-schema property name (`date_of_birth`), so
+      // `...values` already carries it. A trailing
+      // `date_of_birth: values.dateOfBirth || null` used to sit here —
+      // camelCase, which no carrier schema ever emits — so it resolved to
+      // `null` and clobbered whatever the member typed. Harmless in 0.7.x
+      // (which spread `...formData` LAST so the real value won), it became
+      // data-destroying when 0.8.0 inverted the spread order, 422ing every
+      // new Medical Mutual / SimplePay Health enrollment.
       payer_id: streamPayer.id,
       accept: values.termsAndServices,
       tenants_accept: [values.tenantAcknowledgement]
@@ -495,6 +511,7 @@ export const EnterCredentials = (props: EnterCredentialsProps) => {
                       <TextInput
                         key={field.key}
                         label={field.title}
+                        type={field.type === 'date' ? 'date' : 'text'}
                         autoComplete={
                           field.key === 'username' ? 'username' : undefined
                         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-connect-sdk",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "A JavaScript SDK implementing TPAStream's Connect Platform",
   "scripts": {
     "build": "webpack --config webpack.prod-sdk.js --mode=production",


### PR DESCRIPTION
Release of 0.8.3. Single fix; dev PR is LakeEriePartners/stream-connect-js-sdk#8.

## Fix: carriers that ask for Date of Birth could never be connected

A member connecting a carrier whose credential form includes a **Date of Birth** field — Medical Mutual and SimplePay Health — could not complete enrollment. Whatever they typed was discarded before the request left the browser, the backend rejected the submission as missing a required field (HTTP 422), and the form came back with a red validation error. No input format worked, because the value never reached the server.

`EnterCredentials.onSubmit` spread the carrier's form values and then re-pinned SDK-controlled fields on top, including `date_of_birth: values.dateOfBirth || null`. Carrier form values are keyed by their JSON-schema property name — `date_of_birth`, snake_case — so the camelCase lookup was always `undefined` and the `|| null` overwrote the member's input.

That line was inherited from 0.7.x, which spread `...formData` **last** so the member's value won. 0.8.0 inverted the spread order so carrier schemas can't clobber `payer_id` / `accept` / `tenants_accept`, which silently promoted a dead line into data loss. The re-pin is gone; the `payer_id` / consent guards are unchanged.

Date fields also render as a native date input now. Carrier schemas mark them `{"type": "string", "format": "date"}`, which 0.8.x rendered as a bare text box with no format hint even though the backend's WTForms `DateField` only parses ISO `YYYY-MM-DD`.

The React Native hook (`stream-connect-sdk-hook`) kept the 0.7.x spread order and was never affected.

## Impact

Introduced in 0.8.0 (2026-05-17), so roughly ten weeks in the field. It stayed invisible because the backend only validates the onboard form when creating a *new* policy holder — reconnecting an existing one was unaffected.

Measured on Medical Mutual: new policy holders carrying a date of birth ran 100% Jan–Apr (6/6, 7/7, 7/7, 3/3), then fell to 0/3 in May, 6/59 in June, 2/57 in July — the cliff lands on the 0.8.0 release. 184 SDK submissions over the last 60 days across four customers were affected.

## Verification

`npm run test` (biome + tsc) passes. The affected carriers' generated schemas were confirmed to emit `date_of_birth: {type: "string", format: "date", required: true}`, so the new `date` branch fires. Both spread orders were replayed against the real value shape to confirm the regression reproduces and the fix corrects it, with the `payer_id` guard intact.
