### PR TITLE
Release 0.8.3 follow-up: bump in-bundle VERSION constants

### DIFF
--- a/assets/sdk/components/SDK.tsx
+++ b/assets/sdk/components/SDK.tsx
@@ -41,7 +41,7 @@ import { PolicyHolderDetail } from './PolicyHolderDetail';
 import { SelectEnrollProcess } from './SelectEnrollProcess';
 import { TermsOfUse } from './TermsOfUse';
 
-const VERSION = '0.8.2';
+const VERSION = '0.8.3';
 
 interface SDKProps extends SDKInitOptions {
   /** Computed inside the entry; passed in here so the controller

--- a/assets/sdk/entries/sdk-core.tsx
+++ b/assets/sdk/entries/sdk-core.tsx
@@ -9,7 +9,7 @@ import type { SDKInitOptions } from '../types-init';
 // stylesheet so customers driving their own UI via the renderXxx
 // callbacks aren't forced to ship our ~50 KB of Tailwind output.
 
-const VERSION = '0.8.2';
+const VERSION = '0.8.3';
 
 const ORIGIN_POLICY_DOCS_URL =
   'https://developers.tpastream.com/connect/origin-policy';


### PR DESCRIPTION
Follow-up to #107, which must not ship without this.

#107 bumped `package.json` to 0.8.3 but left the two hardcoded `VERSION` constants at `0.8.2`, so the published bundle would have reported itself as the previous version.

- `assets/sdk/components/SDK.tsx:44` — passed to `sdkAxiosMaker` and sent on every backend request; this is the `version` field on server-side SDK log lines.
- `assets/sdk/entries/sdk-core.tsx:12` — console banner only.

The first is the operationally important one. It's how we identify which customer is running which SDK build, and 0.8.3 is a fix four customers need to pick up — shipping a build that reports 0.8.2 would have made the rollout impossible to verify.

Caught during release prep by grepping the built bundle for the version string instead of trusting `package.json`.

Both constants are hand-maintained duplicates of `package.json`'s `version`, which is why they drifted. Deriving them at build time (webpack `DefinePlugin`) would prevent a recurrence; left out here to keep the release moving.

Dev PR: LakeEriePartners/stream-connect-js-sdk#9. `npm test` (biome + tsc) passes.
