### PR TITLE
Release 0.8.3 docs: README + CDN references

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 ## Version
 
+### 0.8.3
+
+Fix: carriers whose credential form asks for a Date of Birth (Medical Mutual, SimplePay Health) could not be connected at all. The value was discarded before submit, so the server rejected the enrollment as missing a required field and no input format worked. Regression introduced in 0.8.0. Date fields now render as a native date input.
+
+### 0.8.2
+
+Patient Access API (OAuth) connections finish with a self-dismissing "Connected" toast and return the member to the carrier picker instead of dead-ending on a full-page end widget. Tapping an already-connected carrier opens a status view first. Fix: 2FA-required carriers reach the verification-method picker rather than a false "Connected". `StreamConnect()` refuses to mount on insecure (plain-HTTP) host pages.
+
 ### 0.8.1
 
 Handle expired `connectAccessToken` cleanly. Long-lived pages no longer surface the misleading 422 when the ~60-minute server-side TTL elapses; integrations opt into transparent refresh via a new server-side endpoint hook, or a clean expiry callback as a fallback. See the [Refreshing an expired token](./docs/connect-access-token.md#refreshing-an-expired-token-081) integration guide.
@@ -20,6 +28,34 @@ This SDK embeds the [EasyEnrollment platform](https://www.easyenrollment.net) in
 
 Latest highlights below. The full per-version changelog lives in
 [CHANGELOG.md](./CHANGELOG.md).
+
+### 0.8.3 highlights
+
+* Fix: a carrier whose credential form includes a **Date of Birth**
+  field — Medical Mutual, SimplePay Health — could not be connected.
+  Whatever the member typed was dropped before the request left the
+  browser, so the server rejected the enrollment as missing a required
+  field and returned a validation error no input format could clear.
+  Introduced in 0.8.0 by a spread-order change; ten weeks in the field.
+* Date fields (`{"type": "string", "format": "date"}` in the carrier
+  schema) now render as a native date input rather than a bare text
+  box, so the submitted value is always the ISO `YYYY-MM-DD` the
+  backend expects.
+* The React Native hook (`stream-connect-sdk-hook`) was never affected.
+
+### 0.8.2 highlights
+
+* Patient Access API (OAuth) connections end with a self-dismissing
+  "Connected" toast in the floating panel and return the member to the
+  carrier picker, instead of dead-ending on a full-page end widget.
+* Tapping an already-connected carrier opens a status view (status,
+  last-synced, masked username, claim-sync summary) with credentials
+  gated behind an explicit "Update sign-in info" / "Reconnect".
+* Fix: 2FA-required carriers reach the verification-method picker
+  rather than a false "Connected" — the realtime flow keys off a live
+  validation task rather than `realTimeVerification`.
+* `StreamConnect()` refuses to mount on insecure (plain-HTTP) host
+  pages; `localhost` / `127.0.0.1` / `[::1]` still work for local dev.
 
 ### 0.8.1 highlights
 

--- a/docs/client-usage.md
+++ b/docs/client-usage.md
@@ -11,7 +11,7 @@ Mount the SDK by calling `StreamConnect({...})` with your config. The minimum yo
 ### Via CDN (vanilla HTML, server-rendered, Backbone, jQuery)
 
 ```html
-<script src="https://app.tpastream.com/static/js/sdk-v-0.8.1.js"></script>
+<script src="https://app.tpastream.com/static/js/sdk-v-0.8.3.js"></script>
 <div id="sdk-hook"></div>
 <script>
   window.StreamConnect({
@@ -27,12 +27,16 @@ Mount the SDK by calling `StreamConnect({...})` with your config. The minimum yo
 </script>
 ```
 
-Three CDN forms are supported:
+These CDN forms are supported:
 
-* `sdk-v-0.8.1.js` (current 0.8.x, pinned)
+* `sdk-v-0.8.3.js` (current 0.8.x, pinned)
+* `sdk-v-0.8.2.js` (0.8.2, pinned)
+* `sdk-v-0.8.1.js` (0.8.1, pinned)
 * `sdk-v-0.8.0.js` (0.8.0, pinned)
 * `sdk-v-0.7.7.js` (last 0.7.x, pinned)
 * `sdk.js` (floating pointer to the latest release; updates automatically when a new version ships)
+
+If you pin, note that you do not pick up fixes automatically. 0.8.3 fixes a bug that made Medical Mutual and SimplePay Health impossible to connect, so pinned integrations on 0.8.0–0.8.2 should move up.
 
 Pinned versions stay available indefinitely. See [Migrating from 0.7 to 0.8](./migration-0.7-to-0.8.md) for the breaking-change story before flipping the floating pointer in production.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,7 +19,7 @@ Here is what the test htmlscript looks like.
 ```
 
 `<script src="https://app.tpastream.com/static/js/sdk.js"></script>` in the head will bring down the latest version of the StreamConnect SDK. If you need to pin to a specific version, change the src to something like
-`<script src="https://app.tpastream.com/static/js/sdk-v-0.8.1.js"></script>`. Pinned versions remain available indefinitely.
+`<script src="https://app.tpastream.com/static/js/sdk-v-0.8.3.js"></script>`. Pinned versions remain available indefinitely.
 
 The 0.8 SDK is visually self-contained: it does not require Bootstrap, jQuery, FontAwesome, or any other host-page CSS. Host pages that already load Bootstrap can keep doing so without conflict. SDK styles use a `tpa-` class prefix to avoid name collisions with host CSS, and the reset/theme variables are wrapped under `.tpa-sdk-root` so they only affect the SDK subtree.
 


### PR DESCRIPTION
Docs-only follow-up to #107 / #108. No code, no version bump — 0.8.3 is already published to npm and tagged `v0.8.3`.

Dev PR: LakeEriePartners/stream-connect-js-sdk#10.

## README

The `## Version` and `## Change Log` sections had stalled at **0.8.1**. 0.8.2 was never added, so this fills that pre-existing gap as well as adding 0.8.3. The version ladder now runs 0.8.3 → 0.8.2 → 0.8.1 → 0.8.0 in both sections.

## CDN references

`docs/quickstart.md` and `docs/client-usage.md` both pinned `sdk-v-0.8.1.js` as the current version. Bumped to 0.8.3, and the supported-forms list now includes the 0.8.2 and 0.8.1 pins that were missing. Also corrected "Three CDN forms are supported" — there were already four listed, and this makes six.

Added an explicit note that pinning means not picking up fixes automatically, using 0.8.3 as the concrete case: a pinned integration on 0.8.0–0.8.2 **cannot connect Medical Mutual or SimplePay Health at all**. Pinned integrations are precisely the ones that don't get this fix for free, so it's worth stating plainly.

## Ordering

These docs advertise `https://app.tpastream.com/static/js/sdk-v-0.8.3.js`. That build is created by the CDN bake in the `stream` repo (LakeEriePartners/stream#15083), which is open but **not yet merged** — until it deploys, the pinned 0.8.3 URL 404s.

This matters here because `developer-docs` clones this repo's `docs/` at docusaurus build time, so merging propagates to the public docs site on the next build. If that's likely to happen before the CDN bake deploys, hold this PR until #15083 is out.

The floating `sdk.js` pointer referenced throughout the docs is unaffected either way, and is how the overwhelming majority of CDN traffic loads the SDK (10,236 requests vs 42 for all pinned builds combined, over the last 14 days).
