### PR TITLE
docs: fix broken callbacks anchor in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,7 +32,7 @@ Embed the SDK in a WebView via [`react-native-webview`](https://github.com/react
 The older `stream-connect-sdk-hook` npm package (v0.6.2) is deprecated. Existing integrations keep working but won't receive feature updates: no SSE-driven validation, no inline 2FA, no fix-credentials status badges, no PAA support. New integrations should use the WebView pattern.
 
 ## I'd like to create a more customized flow for how a user enters credentials and validation.
-The default recommendation for customizing the SDK flow is to use the various sdk [Callbacks](client-usage.md#callbacks).
+The default recommendation for customizing the SDK flow is to use the various sdk [Callbacks](client-usage.md#lifecycle-callbacks-in-detail).
 
 The SDK renders various steps with default templates which should be editted post render using JS and CSS. However, if you would like
 to create more customized widgets it is possible to turn off the default rendering using the various `renderXStep` values within the
@@ -42,7 +42,7 @@ If you are to turn of the default template rendering, the callbacks associated w
 objects in their parameters which will allow an implementor to mirror all of the functionality previously defined in the default
 template.
 
-Each of the provided information is present in the [Callbacks](client-usage.md#callbacks) docs.
+Each of the provided information is present in the [Callbacks](client-usage.md#lifecycle-callbacks-in-detail) docs.
 
 ## How do I use the data from the SDK?
 The StreamConnect SDK is designed to take in carrier credentials, save them to the TPAStream sytem, and then validate the credentials.


### PR DESCRIPTION
Sync of LakeEriePartners#13, which is already merged there.

Two links in `docs/faq.md` pointed at `client-usage.md#callbacks`. There's no "Callbacks" heading in that file — the sections are `Lifecycle callbacks` (the options reference) and `Lifecycle callbacks (in detail)`. Both now target the detail section, which is what the surrounding prose is talking about: the functions and objects each callback hands you.

The anchor is broken both on GitHub and on developers.tpastream.com, which renders these docs by cloning **this** repo at build time (`scripts/clone-sdk-docs.sh`, `SDK_REPO` defaults to `TPAStream/stream-connect-js-sdk`). That's why the fix needs to land here and not only on the LakeEriePartners side — the merged PR there doesn't reach the published docs on its own.

## Verification

- `## Lifecycle callbacks (in detail)` exists at `docs/client-usage.md:209` on this branch, and `client-usage.md` is identical between the two repos, so the target resolves.
- After this change `docs/faq.md` is byte-identical to LakeEriePartners master.
- Built developer-docs against a branch carrying this fix: the broken-anchor report goes to zero. Before it read:

```
- Broken anchor on source page path = /sdk/faq:
   -> linking to /sdk/client-usage#callbacks
```

Docs-only; no source or bundle changes.
